### PR TITLE
KAN-32 optimize database fetching

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -49,6 +49,14 @@ service cloud.firestore {
       allow read, update, delete: if false;
     }
 
+    // ── Aggregates ─────────────────────────────────────────────────
+    // Anyone can read aggregate docs (stations + prices in single docs).
+    // Writes happen from client after upsert/submit — allow for authed users.
+    match /aggregates/{docId} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
+
     // ── Deny everything else ──────────────────────────────────────
     match /{document=**} {
       allow read, write: if false;

--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -10,7 +10,7 @@ import '../services/distance_service.dart';
 import '../services/firestore_service.dart';
 import '../services/overpass_service.dart';
 
-enum SortMode { cheapest, nearest }
+enum SortMode { cheapest, nearest, latest }
 
 class StationProvider extends ChangeNotifier {
   List<Station> _stations = [];
@@ -211,6 +211,15 @@ class StationProvider extends ChangeNotifier {
         } else {
           all.sort((a, b) => a.name.compareTo(b.name));
         }
+      case SortMode.latest:
+        all.sort((a, b) {
+          final pa = getPriceForStation(a.id);
+          final pb = getPriceForStation(b.id);
+          if (pa == null && pb == null) return a.name.compareTo(b.name);
+          if (pa == null) return 1;
+          if (pb == null) return -1;
+          return pb.updatedAt.compareTo(pa.updatedAt);
+        });
     }
 
     return all;

--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -1,11 +1,10 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 
 import '../config/constants.dart';
 import '../models/current_price.dart';
 import '../models/fuel_type.dart';
 import '../models/station.dart';
+import '../services/cache_service.dart';
 import '../services/distance_service.dart';
 import '../services/firestore_service.dart';
 import '../services/overpass_service.dart';
@@ -25,9 +24,6 @@ class StationProvider extends ChangeNotifier {
 
   double? _userLat;
   double? _userLng;
-
-  StreamSubscription? _stationsSub;
-  StreamSubscription? _pricesSub;
 
   List<Station> get stations => _stations;
   List<CurrentPrice> get prices => _prices;
@@ -94,29 +90,64 @@ class StationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Load stations and prices. Reads from local cache first; falls back
+  /// to Firestore aggregate docs (2 reads) if cache is stale or empty.
   Future<void> loadStations() async {
     _isLoading = true;
     notifyListeners();
 
-    // Cancel any existing subscriptions
-    await _stationsSub?.cancel();
-    await _pricesSub?.cancel();
+    try {
+      // Try local cache first (0 Firestore reads)
+      final cachedStations = await CacheService.getCachedStations();
+      final cachedPrices = await CacheService.getCachedPrices();
 
-    _stationsSub = FirestoreService.stationsStream().listen((stations) {
-      _stations = stations;
+      if (cachedStations != null && cachedPrices != null) {
+        _stations = cachedStations;
+        _prices = cachedPrices;
+        _isLoading = false;
+        notifyListeners();
+        return;
+      }
+
+      // Cache miss — read from Firestore aggregate docs (2 reads)
+      await _fetchFromFirestore();
+    } catch (e) {
+      debugPrint('Failed to load stations: $e');
+    } finally {
       _isLoading = false;
       notifyListeners();
-    });
+    }
+  }
 
-    _pricesSub = FirestoreService.currentPricesStream().listen((prices) {
-      _prices = prices;
+  /// Force-refresh from Firestore aggregate docs, bypassing cache.
+  Future<void> refreshFromFirestore() async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      await _fetchFromFirestore();
+    } catch (e) {
+      debugPrint('Failed to refresh from Firestore: $e');
+    } finally {
+      _isLoading = false;
       notifyListeners();
-    });
+    }
+  }
+
+  Future<void> _fetchFromFirestore() async {
+    final stations = await FirestoreService.getStations();
+    final prices = await FirestoreService.getPrices();
+
+    _stations = stations;
+    _prices = prices;
+
+    // Update local cache
+    await CacheService.cacheStations(stations);
+    await CacheService.cachePrices(prices);
   }
 
   /// Fetch stations from Overpass near [lat],[lng] and upsert into Firestore.
-  /// The Firestore stream subscription (from [loadStations]) will
-  /// automatically pick up the new data.
+  /// Then refresh local data from Firestore.
   Future<void> fetchNearbyStations(double lat, double lng) async {
     try {
       final stations = await OverpassService.fetchNearbyStations(
@@ -133,9 +164,11 @@ class StationProvider extends ChangeNotifier {
       debugPrint('Failed to fetch nearby stations: $e');
       await FirestoreService.seedIfEmpty();
     }
+    await refreshFromFirestore();
   }
 
   /// Fetch ALL fuel stations in Norway from Overpass and upsert into Firestore.
+  /// Then refresh local data from Firestore.
   Future<void> fetchAllNorwayStations() async {
     try {
       final stations = await OverpassService.fetchAllNorwayStations();
@@ -153,6 +186,7 @@ class StationProvider extends ChangeNotifier {
         debugPrint('Seed fallback also failed: $e2');
       }
     }
+    await refreshFromFirestore();
   }
 
   void setFuelType(FuelType type) {
@@ -223,12 +257,5 @@ class StationProvider extends ChangeNotifier {
     }
 
     return all;
-  }
-
-  @override
-  void dispose() {
-    _stationsSub?.cancel();
-    _pricesSub?.cancel();
-    super.dispose();
   }
 }

--- a/lib/screens/map/widgets/station_bottom_sheet.dart
+++ b/lib/screens/map/widgets/station_bottom_sheet.dart
@@ -71,16 +71,23 @@ class StationBottomSheet extends StatelessWidget {
                             style: Theme.of(context).textTheme.titleSmall,
                           ),
                           const Spacer(),
-                          SegmentedButton<SortMode>(
-                            segments: const [
-                              ButtonSegment(value: SortMode.cheapest, label: Text('Cheapest')),
-                              ButtonSegment(value: SortMode.nearest, label: Text('Nearest')),
+                          PopupMenuButton<SortMode>(
+                            initialValue: stationProvider.sortMode,
+                            onSelected: stationProvider.setSortMode,
+                            itemBuilder: (_) => const [
+                              PopupMenuItem(value: SortMode.cheapest, child: Text('Cheapest')),
+                              PopupMenuItem(value: SortMode.nearest, child: Text('Nearest')),
+                              PopupMenuItem(value: SortMode.latest, child: Text('Latest')),
                             ],
-                            selected: {stationProvider.sortMode},
-                            onSelectionChanged: (s) => stationProvider.setSortMode(s.first),
-                            style: ButtonStyle(
-                              visualDensity: VisualDensity.compact,
-                              textStyle: WidgetStatePropertyAll(Theme.of(context).textTheme.labelSmall),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  'Sort: ${stationProvider.sortMode.name[0].toUpperCase()}${stationProvider.sortMode.name.substring(1)}',
+                                  style: Theme.of(context).textTheme.labelSmall,
+                                ),
+                                const Icon(Icons.arrow_drop_down, size: 18),
+                              ],
                             ),
                           ),
                         ],

--- a/lib/screens/station_detail/station_list_screen.dart
+++ b/lib/screens/station_detail/station_list_screen.dart
@@ -41,16 +41,23 @@ class StationListScreen extends StatelessWidget {
               children: [
                 Text('${sorted.length} stations', style: Theme.of(context).textTheme.bodySmall),
                 const Spacer(),
-                SegmentedButton<SortMode>(
-                  segments: const [
-                    ButtonSegment(value: SortMode.cheapest, label: Text('Cheapest')),
-                    ButtonSegment(value: SortMode.nearest, label: Text('Nearest')),
+                PopupMenuButton<SortMode>(
+                  initialValue: stationProvider.sortMode,
+                  onSelected: stationProvider.setSortMode,
+                  itemBuilder: (_) => const [
+                    PopupMenuItem(value: SortMode.cheapest, child: Text('Cheapest')),
+                    PopupMenuItem(value: SortMode.nearest, child: Text('Nearest')),
+                    PopupMenuItem(value: SortMode.latest, child: Text('Latest')),
                   ],
-                  selected: {stationProvider.sortMode},
-                  onSelectionChanged: (s) => stationProvider.setSortMode(s.first),
-                  style: ButtonStyle(
-                    visualDensity: VisualDensity.compact,
-                    textStyle: WidgetStatePropertyAll(Theme.of(context).textTheme.labelSmall),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'Sort: ${stationProvider.sortMode.name[0].toUpperCase()}${stationProvider.sortMode.name.substring(1)}',
+                        style: Theme.of(context).textTheme.labelSmall,
+                      ),
+                      const Icon(Icons.arrow_drop_down, size: 18),
+                    ],
                   ),
                 ),
               ],

--- a/lib/screens/submit_price/submit_price_screen.dart
+++ b/lib/screens/submit_price/submit_price_screen.dart
@@ -7,6 +7,7 @@ import '../../models/fuel_type.dart';
 import '../../models/station.dart';
 import '../../providers/location_provider.dart';
 import '../../providers/price_provider.dart';
+import '../../providers/station_provider.dart';
 import '../../providers/user_provider.dart';
 import '../../services/cooldown_prefs_service.dart';
 import '../../services/distance_service.dart';
@@ -193,6 +194,8 @@ class _SubmitPriceScreenState extends State<SubmitPriceScreen> {
 
     if (successCount > 0) {
       await context.read<UserProvider>().incrementReportCount();
+      // Refresh cached prices so the list/map reflect the new submission
+      context.read<StationProvider>().refreshFromFirestore();
     }
 
     if (!mounted) return;

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/current_price.dart';
+import '../models/station.dart';
+
+class CacheService {
+  static const _stationsKey = 'cached_stations';
+  static const _pricesKey = 'cached_prices';
+  static const _stationsTsKey = 'cached_stations_ts';
+  static const _pricesTsKey = 'cached_prices_ts';
+
+  /// Cache TTL — data older than this is considered stale.
+  static const _ttl = Duration(minutes: 30);
+
+  static Future<void> cacheStations(List<Station> stations) async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = jsonEncode(stations.map((s) => s.toJson()).toList());
+    await prefs.setString(_stationsKey, json);
+    await prefs.setInt(_stationsTsKey, DateTime.now().millisecondsSinceEpoch);
+  }
+
+  static Future<void> cachePrices(List<CurrentPrice> prices) async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = jsonEncode(prices.map((p) => p.toJson()).toList());
+    await prefs.setString(_pricesKey, json);
+    await prefs.setInt(_pricesTsKey, DateTime.now().millisecondsSinceEpoch);
+  }
+
+  static Future<List<Station>?> getCachedStations() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!_isFresh(prefs, _stationsTsKey)) return null;
+    final json = prefs.getString(_stationsKey);
+    if (json == null) return null;
+    final list = jsonDecode(json) as List;
+    return list.map((e) => Station.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  static Future<List<CurrentPrice>?> getCachedPrices() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (!_isFresh(prefs, _pricesTsKey)) return null;
+    final json = prefs.getString(_pricesKey);
+    if (json == null) return null;
+    final list = jsonDecode(json) as List;
+    return list.map((e) => CurrentPrice.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  static bool _isFresh(SharedPreferences prefs, String tsKey) {
+    final ts = prefs.getInt(tsKey);
+    if (ts == null) return false;
+    final age = DateTime.now().millisecondsSinceEpoch - ts;
+    return age < _ttl.inMilliseconds;
+  }
+}

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -49,6 +49,22 @@ class FirestoreService {
       }
     }
 
+    // Build aggregate docs
+    batch.set(
+      _db.collection('aggregates').doc('stations'),
+      {
+        'stations': stations.map((s) => s.toJson()).toList(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      },
+    );
+    batch.set(
+      _db.collection('aggregates').doc('prices'),
+      {
+        'prices': prices.map((p) => p.toJson()).toList(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      },
+    );
+
     await batch.commit();
   }
 
@@ -60,6 +76,7 @@ class FirestoreService {
 
   /// Upsert stations into Firestore. Existing stations are updated, not deleted.
   /// This preserves any linked reports and currentPrices documents.
+  /// Also rebuilds the stations aggregate doc.
   static Future<void> upsertStations(List<Station> stations) async {
     if (stations.isEmpty) return;
 
@@ -69,28 +86,70 @@ class FirestoreService {
       batch.set(ref, station.toJson(), SetOptions(merge: true));
     }
     await batch.commit();
+
+    // Rebuild aggregate from the full collection (1 read of all docs,
+    // but only happens on upsert which is a rare admin/refresh action).
+    await _rebuildStationsAggregate();
   }
 
-  // ── Stations ─────────────────────────────────────────────────────────
+  /// Rebuild the stations aggregate doc from the full collection.
+  static Future<void> _rebuildStationsAggregate() async {
+    final snapshot = await _db.collection('stations').get();
+    final allStations = snapshot.docs.map((doc) {
+      return Station.fromJson(_normalizeTimestamps(doc.data()));
+    }).toList();
 
-  /// Real-time stream of all stations.
-  static Stream<List<Station>> stationsStream() {
-    return _db.collection('stations').snapshots().map((snapshot) {
-      return snapshot.docs.map((doc) {
-        return Station.fromJson(_normalizeTimestamps(doc.data()));
-      }).toList();
+    await _db.collection('aggregates').doc('stations').set({
+      'stations': allStations.map((s) => s.toJson()).toList(),
+      'updatedAt': FieldValue.serverTimestamp(),
     });
   }
 
-  // ── Current Prices ───────────────────────────────────────────────────
+  /// Rebuild the prices aggregate doc from the full collection.
+  static Future<void> _rebuildPricesAggregate() async {
+    final snapshot = await _db.collection('currentPrices').get();
+    final allPrices = snapshot.docs.map((doc) {
+      return CurrentPrice.fromJson(_normalizeTimestamps(doc.data()));
+    }).toList();
 
-  /// Real-time stream of all current prices.
-  static Stream<List<CurrentPrice>> currentPricesStream() {
-    return _db.collection('currentPrices').snapshots().map((snapshot) {
-      return snapshot.docs.map((doc) {
-        return CurrentPrice.fromJson(_normalizeTimestamps(doc.data()));
-      }).toList();
+    await _db.collection('aggregates').doc('prices').set({
+      'prices': allPrices.map((p) => p.toJson()).toList(),
+      'updatedAt': FieldValue.serverTimestamp(),
     });
+  }
+
+  // ── Stations (aggregate reads) ─────────────────────────────────────
+
+  /// One-time read of all stations from the aggregate doc (1 read).
+  static Future<List<Station>> getStations() async {
+    final doc = await _db.collection('aggregates').doc('stations').get();
+    if (!doc.exists) {
+      // Fallback: read individual docs and build aggregate
+      await _rebuildStationsAggregate();
+      return getStations();
+    }
+    final data = doc.data()!;
+    final list = (data['stations'] as List<dynamic>?) ?? [];
+    return list.map((e) {
+      return Station.fromJson(_normalizeTimestamps(Map<String, dynamic>.from(e as Map)));
+    }).toList();
+  }
+
+  // ── Current Prices (aggregate reads) ───────────────────────────────
+
+  /// One-time read of all current prices from the aggregate doc (1 read).
+  static Future<List<CurrentPrice>> getPrices() async {
+    final doc = await _db.collection('aggregates').doc('prices').get();
+    if (!doc.exists) {
+      // Fallback: read individual docs and build aggregate
+      await _rebuildPricesAggregate();
+      return getPrices();
+    }
+    final data = doc.data()!;
+    final list = (data['prices'] as List<dynamic>?) ?? [];
+    return list.map((e) {
+      return CurrentPrice.fromJson(_normalizeTimestamps(Map<String, dynamic>.from(e as Map)));
+    }).toList();
   }
 
   // ── Reports ──────────────────────────────────────────────────────────
@@ -110,6 +169,7 @@ class FirestoreService {
   }
 
   /// Submit a new price report and update the denormalized current price.
+  /// Also rebuilds the prices aggregate doc.
   static Future<void> submitReport({
     required String stationId,
     required FuelType fuelType,
@@ -159,6 +219,9 @@ class FirestoreService {
     );
 
     await batch.commit();
+
+    // Rebuild prices aggregate so other users see updated prices
+    await _rebuildPricesAggregate();
   }
 
   /// Returns the most recent report time for a user+station+fuelType combo,


### PR DESCRIPTION
This PR tries to optimize Firestore fetching 

- Aggregate documents - Instead of reading 30+ individual station docs and 29+ price docs, all station data is now stored in a single aggregates/stations document and all price data in a single aggregates/prices document. Loading the
entire  dataset costs 2 reads instead of 59. These aggregate docs are rebuilt automatically whenever stations are upserted or prices are submitted.

- One-time reads — The real-time snapshot listeners were replaced with one-shot .get() calls. The app only reads from Firestore when explicitly needed (app launch or manual refresh), eliminating all background read traffic.

- Local caching — Station and price data is cached locally using SharedPreferences with a 30-minute TTL. If the cache is  fresh, the app serves data entirely from disk — zero Firestore reads. The cache is updated whenever data is fetched from Firestore.