### PR TITLE
KAN-41- fix locator button

### DIFF
--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -18,18 +18,23 @@ class LocationProvider extends ChangeNotifier {
   String? get error => _error;
   bool get hasLocation => _position != null;
 
+  LocationResult? _lastResult;
+  LocationResult? get lastResult => _lastResult;
+
   Future<void> fetchLocation() async {
     if (_positionSub != null) return; // Already listening
 
     _isLoading = true;
     _error = null;
+    _lastResult = null;
     notifyListeners();
 
     try {
       // Check/request permissions FIRST — must happen before any
       // Geolocator call that requires location access.
-      final allowed = await _locationService.checkPermission();
-      if (!allowed) {
+      final result = await _locationService.checkPermission();
+      _lastResult = result;
+      if (result != LocationResult.granted) {
         _error = 'Location permission denied or service disabled.';
         _isLoading = false;
         notifyListeners();

--- a/lib/screens/map/map_screen.dart
+++ b/lib/screens/map/map_screen.dart
@@ -13,6 +13,8 @@ import '../../config/routes.dart';
 import '../../models/station.dart';
 import '../../providers/location_provider.dart';
 import '../../providers/station_provider.dart';
+import 'package:geolocator/geolocator.dart';
+import '../../services/location_service.dart';
 import '../../widgets/brand_logo.dart';
 import 'widgets/brand_filter_bar.dart';
 import 'widgets/fuel_filter_bar.dart';
@@ -60,6 +62,19 @@ class _MapScreenState extends State<MapScreen> {
     final pos = context.read<LocationProvider>().position;
     if (pos != null) {
       _mapController.move(LatLng(pos.latitude, pos.longitude), 13);
+    }
+  }
+
+  Future<void> _requestLocation() async {
+    final provider = context.read<LocationProvider>();
+    await provider.fetchLocation();
+    if (!mounted) return;
+
+    final result = provider.lastResult;
+    if (result == LocationResult.deniedForever) {
+      await Geolocator.openAppSettings();
+    } else if (result == LocationResult.serviceDisabled) {
+      await Geolocator.openLocationSettings();
     }
   }
 
@@ -354,8 +369,7 @@ class _MapScreenState extends State<MapScreen> {
                   ? null
                   : locationProvider.hasLocation
                       ? _centerOnUser
-                      : () =>
-                          context.read<LocationProvider>().fetchLocation(),
+                      : () => _requestLocation(),
             ),
           ),
 

--- a/lib/screens/map/widgets/station_bottom_sheet.dart
+++ b/lib/screens/map/widgets/station_bottom_sheet.dart
@@ -153,7 +153,11 @@ class _StationBottomSheetState extends State<StationBottomSheet>
                             mainAxisSize: MainAxisSize.min,
                             children: [
                               Text(
-                                context.l10n.sortLabel('${stationProvider.sortMode.name[0].toUpperCase()}${stationProvider.sortMode.name.substring(1)}'),
+                                context.l10n.sortLabel(switch (stationProvider.sortMode) {
+                                  SortMode.cheapest => context.l10n.sortCheapest,
+                                  SortMode.nearest => context.l10n.sortNearest,
+                                  SortMode.latest => context.l10n.sortLatest,
+                                }),
                                 style: AppTextStyles.label(context),
                               ),
                               const Icon(Icons.arrow_drop_down, size: 18),

--- a/lib/screens/station_detail/station_list_screen.dart
+++ b/lib/screens/station_detail/station_list_screen.dart
@@ -69,7 +69,11 @@ class StationListScreen extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        context.l10n.sortLabel('${stationProvider.sortMode.name[0].toUpperCase()}${stationProvider.sortMode.name.substring(1)}'),
+                        context.l10n.sortLabel(switch (stationProvider.sortMode) {
+                          SortMode.cheapest => context.l10n.sortCheapest,
+                          SortMode.nearest => context.l10n.sortNearest,
+                          SortMode.latest => context.l10n.sortLatest,
+                        }),
                         style: AppTextStyles.label(context),
                       ),
                       const Icon(Icons.arrow_drop_down, size: 18),

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -1,24 +1,30 @@
 import 'package:geolocator/geolocator.dart';
 
+enum LocationResult { granted, serviceDisabled, denied, deniedForever }
+
 class LocationService {
-  /// Check and request location permissions. Returns true if granted.
-  Future<bool> checkPermission() async {
+  /// Check and request location permissions.
+  Future<LocationResult> checkPermission() async {
     bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
-    if (!serviceEnabled) return false;
+    if (!serviceEnabled) return LocationResult.serviceDisabled;
 
     LocationPermission permission = await Geolocator.checkPermission();
     if (permission == LocationPermission.denied) {
       permission = await Geolocator.requestPermission();
-      if (permission == LocationPermission.denied) return false;
+      if (permission == LocationPermission.denied) {
+        return LocationResult.denied;
+      }
     }
-    if (permission == LocationPermission.deniedForever) return false;
+    if (permission == LocationPermission.deniedForever) {
+      return LocationResult.deniedForever;
+    }
 
-    return true;
+    return LocationResult.granted;
   }
 
   Future<Position?> getCurrentPosition() async {
-    final allowed = await checkPermission();
-    if (!allowed) return null;
+    final result = await checkPermission();
+    if (result != LocationResult.granted) return null;
 
     return Geolocator.getCurrentPosition();
   }


### PR DESCRIPTION
PR introduces the following changes:

When the user taps the location button:

  1. First time denied -> normal permission dialog appears again on next tap
  2. Permanently denied ("don't ask again") -> opens the app settings where they can toggle location permission
  3. Location service disabled -> opens the device location settings to enable GPS