### PR TITLE
KAN-53 - implement admin mode

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,16 +2,23 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
+    // ── Helper: check if user is admin ──
+    function isAdmin() {
+      return request.auth != null
+             && exists(/databases/$(database)/documents/users/$(request.auth.uid))
+             && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
+    }
+
     // ── Stations ──────────────────────────────────────────────────
-    // Anyone can read stations. No client-side writes (seeded by admin/backend).
+    // Anyone can read stations. Admins can write (for approving new stations).
     match /stations/{stationId} {
       allow read: if true;
-      allow write: if false;
+      allow write: if isAdmin();
 
       // ── Price Reports (subcollection) ───────────────────────────
       // Anyone can read reports.
       // Only authenticated (non-anonymous) users can create reports.
-      // Reports are immutable once created — no updates or deletes.
+      // Admins can delete reports.
       match /reports/{reportId} {
         allow read: if true;
         allow create: if request.auth != null
@@ -21,7 +28,8 @@ service cloud.firestore {
                       && request.resource.data.price is number
                       && request.resource.data.price > 0
                       && request.resource.data.price < 100;
-        allow update, delete: if false;
+        allow update: if false;
+        allow delete: if isAdmin();
       }
     }
 
@@ -36,9 +44,17 @@ service cloud.firestore {
     }
 
     // ── User Profiles ─────────────────────────────────────────────
-    // Users can only read and write their own profile.
+    // Users can read and write their own profile, but cannot set isAdmin.
+    // isAdmin is only settable via Firebase Console.
     match /users/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow create: if request.auth != null
+                    && request.auth.uid == uid
+                    && !request.resource.data.keys().hasAny(['isAdmin']);
+      allow update: if request.auth != null
+                    && request.auth.uid == uid
+                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['isAdmin']);
+      allow delete: if request.auth != null && request.auth.uid == uid;
     }
 
     // ── Bug Reports ───────────────────────────────────────────────
@@ -53,7 +69,7 @@ service cloud.firestore {
     // Only authenticated (non-anonymous) users can submit new stations.
     // Users can read/edit/delete their own pending submissions.
     // Users can mark feedback as read on any of their submissions.
-    // Admins manage status/feedback via console.
+    // Admins can read all and update status/feedback.
     match /new_stations/{docId} {
       allow create: if request.auth != null
                     && !request.auth.token.firebase.sign_in_provider.matches('anonymous')
@@ -61,14 +77,17 @@ service cloud.firestore {
                     && request.resource.data.submittedBy == request.auth.uid
                     && request.resource.data.status == 'pending';
       allow read: if request.auth != null
-                  && resource.data.submittedBy == request.auth.uid;
+                  && (resource.data.submittedBy == request.auth.uid || isAdmin());
       allow update: if request.auth != null
-                    && resource.data.submittedBy == request.auth.uid
                     && (
-                      // Allow marking feedback as read
-                      request.resource.data.diff(resource.data).affectedKeys().hasOnly(['feedbackRead'])
-                      // Allow editing own pending submissions (cannot change submittedBy or status)
-                      || (resource.data.status == 'pending'
+                      // Admins can update any field (approve/reject/feedback)
+                      isAdmin()
+                      // Users can mark feedback as read
+                      || (resource.data.submittedBy == request.auth.uid
+                          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['feedbackRead']))
+                      // Users can edit own pending submissions
+                      || (resource.data.submittedBy == request.auth.uid
+                          && resource.data.status == 'pending'
                           && request.resource.data.submittedBy == request.auth.uid
                           && request.resource.data.status == 'pending')
                     );

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,6 +10,7 @@ import 'models/station_submission.dart';
 import 'providers/user_provider.dart';
 import 'screens/auth/auth_screen.dart';
 import 'screens/add_station/add_station_screen.dart';
+import 'screens/admin/admin_submissions_screen.dart';
 import 'screens/settings/bug_report_screen.dart';
 import 'screens/settings/my_station_submissions_screen.dart';
 import 'screens/station_detail/station_detail_screen.dart';
@@ -66,6 +67,10 @@ class App extends StatelessWidget {
           case AppRoutes.myStationSubmissions:
             return MaterialPageRoute(
               builder: (_) => const MyStationSubmissionsScreen(),
+            );
+          case AppRoutes.adminSubmissions:
+            return MaterialPageRoute(
+              builder: (_) => const AdminSubmissionsScreen(),
             );
           default:
             return null;

--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -8,4 +8,5 @@ class AppRoutes {
   static const String bugReport = '/bug-report';
   static const String addStation = '/add-station';
   static const String myStationSubmissions = '/my-station-submissions';
+  static const String adminSubmissions = '/admin-submissions';
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -265,5 +265,22 @@
   "edit": "Edit",
   "delete": "Delete",
   "deleteSubmissionTitle": "Delete Submission?",
-  "deleteSubmissionBody": "This will permanently delete this station submission. This action cannot be undone."
+  "deleteSubmissionBody": "This will permanently delete this station submission. This action cannot be undone.",
+
+  "adminSection": "ADMIN",
+  "adminPanel": "Station Approvals",
+  "adminPanelSubtitle": "Review and approve new station submissions",
+  "noPendingSubmissions": "No pending submissions",
+  "approve": "Approve",
+  "reject": "Reject",
+  "rejectStationTitle": "Reject Station?",
+  "rejectStationBody": "This will reject the submission. You can optionally provide feedback to the user.",
+  "adminFeedbackHint": "Feedback for the user (optional)",
+  "deleteReportTitle": "Delete Report?",
+  "deleteReportBody": "This will permanently remove this price report.",
+  "coordinates": "Coordinates",
+  "approveStationTitle": "Approve Station?",
+  "approveStationBody": "This will add the station to the map. You can optionally send feedback to the user.",
+  "deleteStationTitle": "Delete Station?",
+  "deleteStationBody": "This will permanently remove this station from the map."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1411,6 +1411,102 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'This will permanently delete this station submission. This action cannot be undone.'**
   String get deleteSubmissionBody;
+
+  /// No description provided for @adminSection.
+  ///
+  /// In en, this message translates to:
+  /// **'ADMIN'**
+  String get adminSection;
+
+  /// No description provided for @adminPanel.
+  ///
+  /// In en, this message translates to:
+  /// **'Station Approvals'**
+  String get adminPanel;
+
+  /// No description provided for @adminPanelSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Review and approve new station submissions'**
+  String get adminPanelSubtitle;
+
+  /// No description provided for @noPendingSubmissions.
+  ///
+  /// In en, this message translates to:
+  /// **'No pending submissions'**
+  String get noPendingSubmissions;
+
+  /// No description provided for @approve.
+  ///
+  /// In en, this message translates to:
+  /// **'Approve'**
+  String get approve;
+
+  /// No description provided for @reject.
+  ///
+  /// In en, this message translates to:
+  /// **'Reject'**
+  String get reject;
+
+  /// No description provided for @rejectStationTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Reject Station?'**
+  String get rejectStationTitle;
+
+  /// No description provided for @rejectStationBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This will reject the submission. You can optionally provide feedback to the user.'**
+  String get rejectStationBody;
+
+  /// No description provided for @adminFeedbackHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Feedback for the user (optional)'**
+  String get adminFeedbackHint;
+
+  /// No description provided for @deleteReportTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete Report?'**
+  String get deleteReportTitle;
+
+  /// No description provided for @deleteReportBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This will permanently remove this price report.'**
+  String get deleteReportBody;
+
+  /// No description provided for @coordinates.
+  ///
+  /// In en, this message translates to:
+  /// **'Coordinates'**
+  String get coordinates;
+
+  /// No description provided for @approveStationTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Approve Station?'**
+  String get approveStationTitle;
+
+  /// No description provided for @approveStationBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This will add the station to the map. You can optionally send feedback to the user.'**
+  String get approveStationBody;
+
+  /// No description provided for @deleteStationTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete Station?'**
+  String get deleteStationTitle;
+
+  /// No description provided for @deleteStationBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This will permanently remove this station from the map.'**
+  String get deleteStationBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -723,4 +723,56 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get deleteSubmissionBody =>
       'This will permanently delete this station submission. This action cannot be undone.';
+
+  @override
+  String get adminSection => 'ADMIN';
+
+  @override
+  String get adminPanel => 'Station Approvals';
+
+  @override
+  String get adminPanelSubtitle => 'Review and approve new station submissions';
+
+  @override
+  String get noPendingSubmissions => 'No pending submissions';
+
+  @override
+  String get approve => 'Approve';
+
+  @override
+  String get reject => 'Reject';
+
+  @override
+  String get rejectStationTitle => 'Reject Station?';
+
+  @override
+  String get rejectStationBody =>
+      'This will reject the submission. You can optionally provide feedback to the user.';
+
+  @override
+  String get adminFeedbackHint => 'Feedback for the user (optional)';
+
+  @override
+  String get deleteReportTitle => 'Delete Report?';
+
+  @override
+  String get deleteReportBody =>
+      'This will permanently remove this price report.';
+
+  @override
+  String get coordinates => 'Coordinates';
+
+  @override
+  String get approveStationTitle => 'Approve Station?';
+
+  @override
+  String get approveStationBody =>
+      'This will add the station to the map. You can optionally send feedback to the user.';
+
+  @override
+  String get deleteStationTitle => 'Delete Station?';
+
+  @override
+  String get deleteStationBody =>
+      'This will permanently remove this station from the map.';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -727,4 +727,56 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get deleteSubmissionBody =>
       'Dette vil permanent slette dette stasjonsforslaget. Denne handlingen kan ikke angres.';
+
+  @override
+  String get adminSection => 'ADMIN';
+
+  @override
+  String get adminPanel => 'Stasjonsgodkjenning';
+
+  @override
+  String get adminPanelSubtitle => 'Gjennomgå og godkjenn nye stasjonsforslag';
+
+  @override
+  String get noPendingSubmissions => 'Ingen ventende forslag';
+
+  @override
+  String get approve => 'Godkjenn';
+
+  @override
+  String get reject => 'Avvis';
+
+  @override
+  String get rejectStationTitle => 'Avvise stasjon?';
+
+  @override
+  String get rejectStationBody =>
+      'Dette vil avvise forslaget. Du kan eventuelt gi tilbakemelding til brukeren.';
+
+  @override
+  String get adminFeedbackHint => 'Tilbakemelding til brukeren (valgfritt)';
+
+  @override
+  String get deleteReportTitle => 'Slette rapport?';
+
+  @override
+  String get deleteReportBody =>
+      'Dette vil permanent fjerne denne prisrapporten.';
+
+  @override
+  String get coordinates => 'Koordinater';
+
+  @override
+  String get approveStationTitle => 'Godkjenn stasjon?';
+
+  @override
+  String get approveStationBody =>
+      'Dette vil legge stasjonen til på kartet. Du kan eventuelt sende tilbakemelding til brukeren.';
+
+  @override
+  String get deleteStationTitle => 'Slette stasjon?';
+
+  @override
+  String get deleteStationBody =>
+      'Dette vil permanent fjerne denne stasjonen fra kartet.';
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -243,5 +243,22 @@
   "edit": "Rediger",
   "delete": "Slett",
   "deleteSubmissionTitle": "Slette forslag?",
-  "deleteSubmissionBody": "Dette vil permanent slette dette stasjonsforslaget. Denne handlingen kan ikke angres."
+  "deleteSubmissionBody": "Dette vil permanent slette dette stasjonsforslaget. Denne handlingen kan ikke angres.",
+
+  "adminSection": "ADMIN",
+  "adminPanel": "Stasjonsgodkjenning",
+  "adminPanelSubtitle": "Gjennomgå og godkjenn nye stasjonsforslag",
+  "noPendingSubmissions": "Ingen ventende forslag",
+  "approve": "Godkjenn",
+  "reject": "Avvis",
+  "rejectStationTitle": "Avvise stasjon?",
+  "rejectStationBody": "Dette vil avvise forslaget. Du kan eventuelt gi tilbakemelding til brukeren.",
+  "adminFeedbackHint": "Tilbakemelding til brukeren (valgfritt)",
+  "deleteReportTitle": "Slette rapport?",
+  "deleteReportBody": "Dette vil permanent fjerne denne prisrapporten.",
+  "coordinates": "Koordinater",
+  "approveStationTitle": "Godkjenn stasjon?",
+  "approveStationBody": "Dette vil legge stasjonen til på kartet. Du kan eventuelt sende tilbakemelding til brukeren.",
+  "deleteStationTitle": "Slette stasjon?",
+  "deleteStationBody": "Dette vil permanent fjerne denne stasjonen fra kartet."
 }

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -3,12 +3,14 @@ class UserProfile {
   final String displayName;
   final int reportCount;
   final double trustScore;
+  final bool isAdmin;
 
   const UserProfile({
     required this.id,
     required this.displayName,
     required this.reportCount,
     required this.trustScore,
+    this.isAdmin = false,
   });
 
   factory UserProfile.fromJson(Map<String, dynamic> json) {
@@ -17,6 +19,7 @@ class UserProfile {
       displayName: json['displayName'] as String,
       reportCount: json['reportCount'] as int,
       trustScore: (json['trustScore'] as num).toDouble(),
+      isAdmin: json['isAdmin'] as bool? ?? false,
     );
   }
 

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -24,6 +24,7 @@ class UserProvider extends ChangeNotifier {
   Locale? _locale;
 
   UserProfile get user => _user;
+  bool get isAdmin => _user.isAdmin;
   ThemeMode get themeMode => _themeMode;
   bool get isDarkMode => _themeMode == ThemeMode.dark;
   Locale? get locale => _locale;
@@ -133,6 +134,7 @@ class UserProvider extends ChangeNotifier {
         displayName: displayName,
         reportCount: existing.reportCount,
         trustScore: existing.trustScore,
+        isAdmin: existing.isAdmin,
       );
     } else {
       _user = UserProfile(
@@ -205,6 +207,7 @@ class UserProvider extends ChangeNotifier {
         displayName: displayName,
         reportCount: existing.reportCount,
         trustScore: existing.trustScore,
+        isAdmin: existing.isAdmin,
       );
     } else {
       _user = UserProfile(

--- a/lib/screens/admin/admin_submission_detail_screen.dart
+++ b/lib/screens/admin/admin_submission_detail_screen.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../config/app_colors.dart';
+import '../../config/app_text_styles.dart';
+import '../../l10n/l10n_helper.dart';
+import '../../models/station_submission.dart';
+import '../../services/firestore_service.dart';
+import '../../widgets/brand_logo.dart';
+
+class AdminSubmissionDetailScreen extends StatelessWidget {
+  final StationSubmission submission;
+
+  const AdminSubmissionDetailScreen({super.key, required this.submission});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final tileUrl = isDark
+        ? 'https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png'
+        : 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+    final location = LatLng(submission.latitude, submission.longitude);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          submission.name,
+          style: AppTextStyles.title(context),
+        ),
+        backgroundColor: AppColors.surface(context),
+        elevation: 0,
+      ),
+      backgroundColor: AppColors.background(context),
+      body: ListView(
+        padding: EdgeInsets.fromLTRB(
+          16, 16, 16,
+          MediaQuery.of(context).padding.bottom + 32,
+        ),
+        children: [
+          // Map — tap to open in external map app
+          GestureDetector(
+            onTap: () {
+              final uri = Uri.parse(
+                'https://www.google.com/maps/search/?api=1&query=${submission.latitude},${submission.longitude}',
+              );
+              launchUrl(uri, mode: LaunchMode.externalApplication);
+            },
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: SizedBox(
+                height: 220,
+                child: AbsorbPointer(
+                  child: FlutterMap(
+                options: MapOptions(
+                  initialCenter: location,
+                  initialZoom: 17,
+                  interactionOptions: const InteractionOptions(
+                    flags: InteractiveFlag.none,
+                  ),
+                ),
+                children: [
+                  TileLayer(
+                    urlTemplate: tileUrl,
+                    userAgentPackageName: 'com.example.fuel_price_tracker',
+                  ),
+                  MarkerLayer(
+                    markers: [
+                      Marker(
+                        point: location,
+                        width: 40,
+                        height: 40,
+                        child: Icon(
+                          Icons.location_pin,
+                          color: AppColors.primaryContainer(context),
+                          size: 40,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              ),
+            ),
+          ),
+          ),
+          const SizedBox(height: 20),
+
+          // Station info card
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: AppColors.surface(context),
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: AppColors.border(context), width: 0.5),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    BrandLogo(brand: submission.brand, radius: 22),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            submission.name,
+                            style: AppTextStyles.title(context),
+                          ),
+                          Text(
+                            submission.brand,
+                            style: AppTextStyles.label(context),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                _DetailRow(
+                  icon: Icons.location_on_outlined,
+                  label: context.l10n.addStationAddress,
+                  value: submission.address.isNotEmpty
+                      ? submission.address
+                      : '—',
+                ),
+                const SizedBox(height: 10),
+                _DetailRow(
+                  icon: Icons.location_city_outlined,
+                  label: context.l10n.addStationCity,
+                  value: submission.city.isNotEmpty
+                      ? submission.city
+                      : '—',
+                ),
+                const SizedBox(height: 10),
+                _DetailRow(
+                  icon: Icons.my_location_outlined,
+                  label: context.l10n.coordinates,
+                  value: '${submission.latitude.toStringAsFixed(5)}, '
+                      '${submission.longitude.toStringAsFixed(5)}',
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // Approve / Reject buttons
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: () => _reject(context),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.red,
+                    side: const BorderSide(color: Colors.red),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  icon: const Icon(Icons.close, size: 18),
+                  label: Text(context.l10n.reject),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: FilledButton.icon(
+                  onPressed: () => _approve(context),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                  ),
+                  icon: const Icon(Icons.check, size: 18),
+                  label: Text(context.l10n.approve),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _approve(BuildContext context) async {
+    final feedbackController = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.approveStationTitle),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(context.l10n.approveStationBody),
+            const SizedBox(height: 12),
+            TextField(
+              controller: feedbackController,
+              decoration: InputDecoration(
+                hintText: context.l10n.adminFeedbackHint,
+              ),
+              maxLines: 3,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(context.l10n.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(context.l10n.approve),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await FirestoreService.approveStation(
+      submission,
+      feedback: feedbackController.text.trim(),
+    );
+    feedbackController.dispose();
+    if (context.mounted) Navigator.pop(context, true);
+  }
+
+  Future<void> _reject(BuildContext context) async {
+    final feedbackController = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.rejectStationTitle),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(context.l10n.rejectStationBody),
+            const SizedBox(height: 12),
+            TextField(
+              controller: feedbackController,
+              decoration: InputDecoration(
+                hintText: context.l10n.adminFeedbackHint,
+              ),
+              maxLines: 3,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(context.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: Text(context.l10n.reject),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await FirestoreService.rejectStation(
+      submission.id,
+      feedback: feedbackController.text.trim(),
+    );
+    feedbackController.dispose();
+    if (context.mounted) Navigator.pop(context, true);
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _DetailRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 18, color: AppColors.textMuted(context)),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(label, style: AppTextStyles.meta(context)),
+              Text(value, style: AppTextStyles.body(context)),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/admin/admin_submissions_screen.dart
+++ b/lib/screens/admin/admin_submissions_screen.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/material.dart';
+
+import '../../config/app_colors.dart';
+import '../../config/app_text_styles.dart';
+import '../../l10n/l10n_helper.dart';
+import '../../models/station_submission.dart';
+import '../../services/firestore_service.dart';
+import '../../widgets/brand_logo.dart';
+import 'admin_submission_detail_screen.dart';
+
+class AdminSubmissionsScreen extends StatefulWidget {
+  const AdminSubmissionsScreen({super.key});
+
+  @override
+  State<AdminSubmissionsScreen> createState() => _AdminSubmissionsScreenState();
+}
+
+class _AdminSubmissionsScreenState extends State<AdminSubmissionsScreen> {
+  List<StationSubmission>? _submissions;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final submissions = await FirestoreService.getAllPendingSubmissions();
+    if (!mounted) return;
+    setState(() {
+      _submissions = submissions;
+      _isLoading = false;
+    });
+  }
+
+  Future<void> _approve(StationSubmission sub) async {
+    final feedbackController = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.approveStationTitle),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(context.l10n.approveStationBody),
+            const SizedBox(height: 12),
+            TextField(
+              controller: feedbackController,
+              decoration: InputDecoration(
+                hintText: context.l10n.adminFeedbackHint,
+              ),
+              maxLines: 3,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(context.l10n.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(context.l10n.approve),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await FirestoreService.approveStation(
+      sub,
+      feedback: feedbackController.text.trim(),
+    );
+    feedbackController.dispose();
+    if (mounted) _load();
+  }
+
+  Future<void> _reject(StationSubmission sub) async {
+    final feedbackController = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.rejectStationTitle),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(context.l10n.rejectStationBody),
+            const SizedBox(height: 12),
+            TextField(
+              controller: feedbackController,
+              decoration: InputDecoration(
+                hintText: context.l10n.adminFeedbackHint,
+              ),
+              maxLines: 3,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(context.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: Text(context.l10n.reject),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await FirestoreService.rejectStation(
+      sub.id,
+      feedback: feedbackController.text.trim(),
+    );
+    feedbackController.dispose();
+    if (mounted) _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          context.l10n.adminPanel,
+          style: AppTextStyles.title(context),
+        ),
+        backgroundColor: AppColors.surface(context),
+        elevation: 0,
+      ),
+      backgroundColor: AppColors.background(context),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _submissions == null || _submissions!.isEmpty
+              ? Center(
+                  child: Text(
+                    context.l10n.noPendingSubmissions,
+                    style: AppTextStyles.label(context),
+                  ),
+                )
+              : ListView.separated(
+                  padding: EdgeInsets.fromLTRB(
+                    16, 16, 16,
+                    MediaQuery.of(context).padding.bottom + 16,
+                  ),
+                  itemCount: _submissions!.length,
+                  separatorBuilder: (_, _) => const SizedBox(height: 10),
+                  itemBuilder: (context, index) {
+                    final sub = _submissions![index];
+                    return _AdminSubmissionCard(
+                      submission: sub,
+                      onApprove: () => _approve(sub),
+                      onReject: () => _reject(sub),
+                      onTap: () async {
+                        final result = await Navigator.push<bool>(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminSubmissionDetailScreen(
+                              submission: sub,
+                            ),
+                          ),
+                        );
+                        if (result == true) _load();
+                      },
+                    );
+                  },
+                ),
+    );
+  }
+}
+
+class _AdminSubmissionCard extends StatelessWidget {
+  final StationSubmission submission;
+  final VoidCallback onApprove;
+  final VoidCallback onReject;
+  final VoidCallback onTap;
+
+  const _AdminSubmissionCard({
+    required this.submission,
+    required this.onApprove,
+    required this.onReject,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(14),
+      onTap: onTap,
+      child: Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface(context),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.border(context), width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              BrandLogo(brand: submission.brand, radius: 18),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      submission.name,
+                      style: AppTextStyles.bodyMedium(context),
+                    ),
+                    Text(
+                      '${submission.brand} — ${submission.city}',
+                      style: AppTextStyles.meta(context),
+                    ),
+                    if (submission.address.isNotEmpty)
+                      Text(
+                        submission.address,
+                        style: AppTextStyles.meta(context),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton.icon(
+                onPressed: onReject,
+                style: TextButton.styleFrom(foregroundColor: Colors.red),
+                icon: const Icon(Icons.close, size: 18),
+                label: Text(context.l10n.reject),
+              ),
+              const SizedBox(width: 8),
+              FilledButton.icon(
+                onPressed: onApprove,
+                icon: const Icon(Icons.check, size: 18),
+                label: Text(context.l10n.approve),
+              ),
+            ],
+          ),
+        ],
+      ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -252,6 +252,30 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   const SizedBox(height: 24),
                 ],
 
+                // ── Admin Panel ──
+                if (userProvider.isAdmin) ...[
+                  Text(
+                    context.l10n.adminSection,
+                    style: AppTextStyles.sectionHeader(context),
+                  ),
+                  const SizedBox(height: 12),
+                  _SettingsCard(
+                    children: [
+                      _SettingsTile(
+                        icon: Icons.admin_panel_settings_outlined,
+                        iconColor: Colors.orange,
+                        title: context.l10n.adminPanel,
+                        subtitle: context.l10n.adminPanelSubtitle,
+                        onTap: () => Navigator.pushNamed(
+                          context,
+                          AppRoutes.adminSubmissions,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                ],
+
                 // ── Map Preferences ──
                 Text(
                   context.l10n.mapPreferences,

--- a/lib/screens/station_detail/station_detail_screen.dart
+++ b/lib/screens/station_detail/station_detail_screen.dart
@@ -12,6 +12,8 @@ import '../../config/routes.dart';
 import '../../models/station.dart';
 import '../../providers/price_provider.dart';
 import '../../providers/station_provider.dart';
+import '../../providers/user_provider.dart';
+import '../../services/firestore_service.dart';
 import '../../widgets/brand_logo.dart';
 import '../../widgets/loading_indicator.dart';
 import 'widgets/price_card.dart';
@@ -59,10 +61,38 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
     }
   }
 
+  Future<void> _deleteStation(StationProvider stationProvider) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(context.l10n.deleteStationTitle),
+        content: Text(context.l10n.deleteStationBody),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(context.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: Text(context.l10n.delete),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    await FirestoreService.deleteStation(widget.station.id);
+    if (mounted) {
+      await stationProvider.refreshFromFirestore();
+      if (mounted) Navigator.pop(context);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final stationProvider = context.watch<StationProvider>();
     final priceProvider = context.watch<PriceProvider>();
+    final userProvider = context.watch<UserProvider>();
     final prices = stationProvider.getPricesForStation(widget.station.id);
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final activeColor = AppColors.primaryContainer(context);
@@ -136,6 +166,11 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
               ),
             ),
             actions: [
+              if (userProvider.isAdmin)
+                IconButton(
+                  icon: const Icon(Icons.delete_outline, color: Colors.red),
+                  onPressed: () => _deleteStation(stationProvider),
+                ),
               // Navigate button
               Padding(
                 padding: const EdgeInsets.only(right: 8),
@@ -287,6 +322,45 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                               color: activeColor,
                             ),
                           ),
+                          if (userProvider.isAdmin) ...[
+                            const SizedBox(width: 8),
+                            GestureDetector(
+                              onTap: () async {
+                                final provider = context.read<PriceProvider>();
+                                final confirmed = await showDialog<bool>(
+                                  context: context,
+                                  builder: (ctx) => AlertDialog(
+                                    title: Text(context.l10n.deleteReportTitle),
+                                    content: Text(context.l10n.deleteReportBody),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () => Navigator.pop(ctx, false),
+                                        child: Text(context.l10n.cancel),
+                                      ),
+                                      TextButton(
+                                        onPressed: () => Navigator.pop(ctx, true),
+                                        style: TextButton.styleFrom(foregroundColor: Colors.red),
+                                        child: Text(context.l10n.delete),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                                if (confirmed != true || !mounted) return;
+                                await FirestoreService.deleteReport(
+                                  widget.station.id,
+                                  report.id,
+                                );
+                                if (mounted) {
+                                  provider.loadReports(widget.station.id);
+                                }
+                              },
+                              child: Icon(
+                                Icons.delete_outline,
+                                size: 18,
+                                color: Colors.red.withValues(alpha: 0.7),
+                              ),
+                            ),
+                          ],
                         ],
                       ),
                     );

--- a/lib/screens/submit_price/submit_price_screen.dart
+++ b/lib/screens/submit_price/submit_price_screen.dart
@@ -120,7 +120,11 @@ class _SubmitPriceScreenState extends State<SubmitPriceScreen> {
   Future<void> _submit({bool autoSubmit = false}) async {
     if (!_formKey.currentState!.validate()) return;
 
-    if (_hasValidPhotoMetadata) {
+    final isAdmin = context.read<UserProvider>().isAdmin;
+
+    if (isAdmin) {
+      debugPrint('[SubmitPrice] Location check bypassed — admin user');
+    } else if (_hasValidPhotoMetadata) {
       debugPrint(
         '[SubmitPrice] Location check bypassed — photo metadata valid',
       );

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -173,6 +173,16 @@ class FirestoreService {
     }).toList();
   }
 
+  /// Delete a price report (admin only).
+  static Future<void> deleteReport(String stationId, String reportId) async {
+    await _db
+        .collection('stations')
+        .doc(stationId)
+        .collection('reports')
+        .doc(reportId)
+        .delete();
+  }
+
   /// Submit a new price report and update the denormalized current price.
   /// Also rebuilds the prices aggregate doc.
   static Future<void> submitReport({
@@ -451,6 +461,98 @@ class FirestoreService {
     await _db.collection('new_stations').doc(docId).update({
       'feedbackRead': true,
     });
+  }
+
+  // ── Admin Operations ────────────────────────────────────────────────
+
+  /// Fetch all pending station submissions (admin only).
+  static Future<List<StationSubmission>> getAllPendingSubmissions() async {
+    final snapshot = await _db
+        .collection('new_stations')
+        .where('status', isEqualTo: 'pending')
+        .get();
+
+    return snapshot.docs.map((doc) {
+      return StationSubmission.fromJson(doc.id, _normalizeTimestamps(doc.data()));
+    }).toList();
+  }
+
+  /// Approve a station submission: copy to stations collection,
+  /// update status to approved, rebuild stations aggregate.
+  static Future<void> approveStation(StationSubmission submission, {String? feedback}) async {
+    final stationId = 'user_${submission.id}';
+    final station = Station(
+      id: stationId,
+      name: submission.name,
+      brand: submission.brand,
+      address: submission.address,
+      city: submission.city,
+      latitude: submission.latitude,
+      longitude: submission.longitude,
+    );
+
+    final batch = _db.batch();
+
+    // Add to stations collection
+    batch.set(
+      _db.collection('stations').doc(stationId),
+      station.toJson(),
+    );
+
+    // Update submission status + optional feedback
+    final updateData = <String, dynamic>{'status': 'approved'};
+    if (feedback != null && feedback.isNotEmpty) {
+      updateData['feedback'] = feedback;
+      updateData['feedbackRead'] = false;
+    }
+    batch.update(
+      _db.collection('new_stations').doc(submission.id),
+      updateData,
+    );
+
+    await batch.commit();
+
+    // Append the new station to the aggregate directly
+    // (avoids race condition with batch write propagation)
+    final aggDoc = await _db.collection('aggregates').doc('stations').get();
+    final existing = aggDoc.exists
+        ? ((aggDoc.data()!['stations'] as List<dynamic>?) ?? [])
+            .map((e) => Map<String, dynamic>.from(e as Map))
+            .toList()
+        : <Map<String, dynamic>>[];
+    existing.add(station.toJson());
+    await _db.collection('aggregates').doc('stations').set({
+      'stations': existing,
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  /// Delete a station from the stations collection and remove from aggregate.
+  static Future<void> deleteStation(String stationId) async {
+    await _db.collection('stations').doc(stationId).delete();
+
+    // Remove from aggregate
+    final aggDoc = await _db.collection('aggregates').doc('stations').get();
+    if (aggDoc.exists) {
+      final list = ((aggDoc.data()!['stations'] as List<dynamic>?) ?? [])
+          .map((e) => Map<String, dynamic>.from(e as Map))
+          .where((s) => s['id'] != stationId)
+          .toList();
+      await _db.collection('aggregates').doc('stations').set({
+        'stations': list,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+    }
+  }
+
+  /// Reject a station submission with optional feedback.
+  static Future<void> rejectStation(String docId, {String? feedback}) async {
+    final data = <String, dynamic>{'status': 'rejected'};
+    if (feedback != null && feedback.isNotEmpty) {
+      data['feedback'] = feedback;
+      data['feedbackRead'] = false;
+    }
+    await _db.collection('new_stations').doc(docId).update(data);
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR adds following:

- Admins are designated by setting `isAdmin`: true on their user doc in Firebase Console (cannot be set from
  the client)
- Admins can submit prices for any station in Norway without distance or location checks
- Admins can delete individual price reports from any station's detail page
- Admins can remove stations entirely from the map via a delete button on the station detail page
- Admins can approve or reject user-submitted stations from the "Station Approvals" panel in Settings
- Approving a station copies it to the stations collection and immediately updates the aggregate
- Both approve and reject actions support optional feedback that the user sees as a popup on next app launch
- Firestore rules enforce admin checks server-side via the `isAdmin` field on the user doc, and prevent clients from escalating their own privileges