### PR TITLE
KAN-0 - fix image picker for ocr

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <!-- Required to read GPS metadata from gallery images -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!-- Required to read GPS metadata from gallery images via setRequireOriginal -->
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <application
         android:label="TankVenn"

--- a/android/app/src/main/kotlin/no/fueltracker/fuel_price_tracker/MainActivity.kt
+++ b/android/app/src/main/kotlin/no/fueltracker/fuel_price_tracker/MainActivity.kt
@@ -1,14 +1,17 @@
 package no.fueltracker.fuel_price_tracker
 
 import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.exifinterface.media.ExifInterface
 import io.flutter.embedding.android.FlutterFragmentActivity
@@ -17,30 +20,55 @@ import io.flutter.plugin.common.MethodChannel
 import java.io.File
 import java.io.FileOutputStream
 
+/**
+ * ACTION_PICK opens the default gallery directly (no app-chooser dialog)
+ * and returns a MediaStore URI that supports setRequireOriginal for GPS.
+ */
+class PickImageFromGallery : ActivityResultContract<Unit, Uri?>() {
+    override fun createIntent(context: Context, input: Unit): Intent {
+        return Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
+        return if (resultCode == Activity.RESULT_OK) intent?.data else null
+    }
+}
+
 class MainActivity : FlutterFragmentActivity() {
     private val TAG = "ImageMetadataChannel"
     private val CHANNEL = "no.fueltracker/image_metadata"
     private var pendingResult: MethodChannel.Result? = null
-    private lateinit var pickImageLauncher: ActivityResultLauncher<String>
-    private val PERMISSION_REQUEST_CODE = 9001
+    private lateinit var pickImageLauncher: ActivityResultLauncher<Unit>
+    private lateinit var permissionLauncher: ActivityResultLauncher<String>
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        // GetContent routes through the Android Photo Picker on 13+, which
-        // provides a single-step selection UI and URIs compatible with
-        // setRequireOriginal for unredacted GPS access.
+        // ACTION_PICK opens the gallery directly — no app-chooser popup.
+        // Returned MediaStore URIs support setRequireOriginal for GPS.
         pickImageLauncher = registerForActivityResult(
-            ActivityResultContracts.GetContent()
+            PickImageFromGallery()
         ) { uri: Uri? ->
             if (uri != null) {
                 Log.d(TAG, "Image picked, URI: $uri")
-                handlePickedImage(uri)
+                processPickedImage(uri)
             } else {
                 Log.d(TAG, "User cancelled picker")
                 pendingResult?.success(null)
                 pendingResult = null
             }
+        }
+
+        // Request ACCESS_MEDIA_LOCATION before the picker so the user
+        // sees at most one permission dialog, then the picker opens
+        // immediately.  On subsequent uses the permission is already
+        // granted and the picker launches with no interruption.
+        permissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { granted ->
+            Log.d(TAG, "ACCESS_MEDIA_LOCATION granted=$granted")
+            // Launch picker regardless — GPS will just be null if denied.
+            pickImageLauncher.launch(Unit)
         }
 
         MethodChannel(
@@ -50,74 +78,40 @@ class MainActivity : FlutterFragmentActivity() {
             when (call.method) {
                 "pickImageWithMetadata" -> {
                     pendingResult = result
-                    ensurePermissionsThenPick()
+                    ensurePermissionThenPick()
                 }
                 else -> result.notImplemented()
             }
         }
     }
 
-    private fun ensurePermissionsThenPick() {
-        val perms = mutableListOf<String>()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_MEDIA_IMAGES)
-                != PackageManager.PERMISSION_GRANTED
-            ) {
-                perms.add(Manifest.permission.READ_MEDIA_IMAGES)
-            }
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_MEDIA_LOCATION)
-                != PackageManager.PERMISSION_GRANTED
-            ) {
-                perms.add(Manifest.permission.ACCESS_MEDIA_LOCATION)
-            }
-        }
-
-        if (perms.isNotEmpty()) {
-            Log.d(TAG, "Requesting permissions: $perms")
-            ActivityCompat.requestPermissions(this, perms.toTypedArray(), PERMISSION_REQUEST_CODE)
+    private fun ensurePermissionThenPick() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_MEDIA_LOCATION)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.d(TAG, "Requesting ACCESS_MEDIA_LOCATION before picker")
+            permissionLauncher.launch(Manifest.permission.ACCESS_MEDIA_LOCATION)
         } else {
-            Log.d(TAG, "All permissions granted, launching picker")
-            launchPicker()
+            Log.d(TAG, "Permission already granted, launching picker")
+            pickImageLauncher.launch(Unit)
         }
     }
 
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == PERMISSION_REQUEST_CODE) {
-            for (i in permissions.indices) {
-                val granted = grantResults.getOrNull(i) == PackageManager.PERMISSION_GRANTED
-                Log.d(TAG, "Permission ${permissions[i]}: granted=$granted")
-            }
-            launchPicker()
-        }
-    }
-
-    private fun launchPicker() {
-        pickImageLauncher.launch("image/*")
-    }
-
-    private fun handlePickedImage(uri: Uri) {
+    private fun processPickedImage(uri: Uri) {
         try {
             val metadata = HashMap<String, Any?>()
 
-            // Try setRequireOriginal first (works with Photo Picker URIs),
-            // fall back to plain URI (for document provider URIs).
+            // Try setRequireOriginal first for unredacted GPS,
+            // fall back to plain URI if denied or unsupported.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 try {
                     val originalUri = MediaStore.setRequireOriginal(uri)
                     Log.d(TAG, "Trying original URI: $originalUri")
                     readExifFromUri(originalUri, metadata)
                     Log.d(TAG, "EXIF from original URI: lat=${metadata["latitude"]}, lng=${metadata["longitude"]}")
-                } catch (e: SecurityException) {
-                    Log.w(TAG, "setRequireOriginal denied, falling back to plain URI: ${e.message}")
+                } catch (e: Exception) {
+                    Log.w(TAG, "setRequireOriginal failed, falling back to plain URI: ${e.message}")
                     readExifFromUri(uri, metadata)
                     Log.d(TAG, "EXIF from plain URI: lat=${metadata["latitude"]}, lng=${metadata["longitude"]}")
                 }
@@ -142,7 +136,7 @@ class MainActivity : FlutterFragmentActivity() {
             Log.d(TAG, "Returning: path=${cacheFile.absolutePath}, lat=${metadata["latitude"]}, lng=${metadata["longitude"]}, dt=${metadata["dateTime"]}")
             pendingResult?.success(result)
         } catch (e: Exception) {
-            Log.e(TAG, "handlePickedImage failed", e)
+            Log.e(TAG, "processPickedImage failed", e)
             pendingResult?.error("PICK_ERROR", e.message, null)
         }
         pendingResult = null


### PR DESCRIPTION
This PR does following:

- Removed unnecessary `READ_MEDIA_IMAGES` permission request that caused double permission dialogs                                                             
- Switched from `GetContent() `to `ACTION_PICK` intent to avoid the system app-chooser popup before the gallery                                                  
- Moved `ACCESS_MEDIA_LOCATION` permission request to before the picker so it doesn't interrupt the image selection flow                                       
- Broadened `setRequireOriginal()` exception catch to handle `UnsupportedOperationException` gracefully   