### PR TITLE
KAN-0 - firestore optimizations

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,12 +26,9 @@ void main() async {
   final userProvider = UserProvider();
   userProvider.initialize();
 
-  // Start station loading immediately so data is ready by the time
-  // the map screen renders.  Serves cache first (0 reads), then
-  // falls back to aggregate docs (2 reads), then refreshes from
-  // Overpass in the background.
+  // Load stations from cache or Firestore aggregate (≤2 reads).
   final stationProvider = StationProvider();
-  stationProvider.fetchAllNorwayStations();
+  stationProvider.loadStations();
 
   runApp(
     MultiProvider(

--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/foundation.dart';
 
-import '../config/constants.dart';
 import '../models/current_price.dart';
 import '../models/fuel_type.dart';
 import '../models/station.dart';
 import '../services/cache_service.dart';
 import '../services/distance_service.dart';
 import '../services/firestore_service.dart';
-import '../services/overpass_service.dart';
 
 enum SortMode { cheapest, nearest, latest }
 
@@ -98,26 +96,13 @@ class StationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Load stations and prices. Reads from local cache first; falls back
-  /// to Firestore aggregate docs (2 reads) if cache is stale or empty.
+  /// Load stations and prices from Firestore aggregate docs (2 reads).
+  /// Called on app startup.
   Future<void> loadStations() async {
     _isLoading = true;
     notifyListeners();
 
     try {
-      // Try local cache first (0 Firestore reads)
-      final cachedStations = await CacheService.getCachedStations();
-      final cachedPrices = await CacheService.getCachedPrices();
-
-      if (cachedStations != null && cachedPrices != null) {
-        _stations = cachedStations;
-        _prices = cachedPrices;
-        _isLoading = false;
-        notifyListeners();
-        return;
-      }
-
-      // Cache miss — read from Firestore aggregate docs (2 reads)
       await _fetchFromFirestore();
     } catch (e) {
       debugPrint('Failed to load stations: $e');
@@ -127,7 +112,7 @@ class StationProvider extends ChangeNotifier {
     }
   }
 
-  /// Force-refresh from Firestore aggregate docs, bypassing cache.
+  /// Re-read aggregates from Firestore, bypassing cache (2 reads).
   Future<void> refreshFromFirestore() async {
     _isLoading = true;
     notifyListeners();
@@ -136,6 +121,21 @@ class StationProvider extends ChangeNotifier {
       await _fetchFromFirestore();
     } catch (e) {
       debugPrint('Failed to refresh from Firestore: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  /// Refresh by re-reading aggregates from Firestore, bypassing cache (2 reads).
+  Future<void> refreshStations() async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      await _fetchFromFirestore();
+    } catch (e) {
+      debugPrint('Failed to refresh stations: $e');
     } finally {
       _isLoading = false;
       notifyListeners();
@@ -152,58 +152,6 @@ class StationProvider extends ChangeNotifier {
     // Update local cache
     await CacheService.cacheStations(stations);
     await CacheService.cachePrices(prices);
-  }
-
-  /// Fetch stations from Overpass near [lat],[lng] and upsert into Firestore.
-  /// Then refresh local data from Firestore.
-  Future<void> fetchNearbyStations(double lat, double lng) async {
-    try {
-      final stations = await OverpassService.fetchNearbyStations(
-        lat: lat,
-        lng: lng,
-        radiusMeters: AppConstants.defaultSearchRadiusMeters,
-      );
-      if (stations.isNotEmpty) {
-        await FirestoreService.upsertStations(stations);
-      } else {
-        await FirestoreService.seedIfEmpty();
-      }
-    } catch (e) {
-      debugPrint('Failed to fetch nearby stations: $e');
-      await FirestoreService.seedIfEmpty();
-    }
-    await refreshFromFirestore();
-  }
-
-  /// Fetch ALL fuel stations in Norway from Overpass and upsert into Firestore.
-  /// Serves cached/aggregate data immediately (≤2 reads), then refreshes from
-  /// Overpass in the background and updates the UI when done.
-  Future<void> fetchAllNorwayStations() async {
-    // 1. Show cached or aggregate data immediately so the UI isn't empty.
-    if (_stations.isEmpty) {
-      await loadStations();
-    }
-
-    // 2. Fetch from Overpass and update Firestore + local state.
-    try {
-      final stations = await OverpassService.fetchAllNorwayStations();
-      debugPrint('Overpass returned ${stations.length} Norway stations');
-      if (stations.isNotEmpty) {
-        await FirestoreService.upsertStations(stations);
-      } else {
-        // Overpass returned nothing — rebuild aggregate from stations
-        // collection so manually-added stations still appear.
-        await FirestoreService.rebuildStationsAggregate();
-      }
-    } catch (e) {
-      debugPrint('Failed to fetch/save Norway stations: $e');
-      try {
-        await FirestoreService.rebuildStationsAggregate();
-      } catch (e2) {
-        debugPrint('Aggregate rebuild also failed: $e2');
-      }
-    }
-    await refreshFromFirestore();
   }
 
   void setFuelType(FuelType type) {

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -42,7 +42,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _isRefreshing = true);
 
     final stationProvider = context.read<StationProvider>();
-    await stationProvider.fetchAllNorwayStations();
+    await stationProvider.refreshStations();
 
     if (mounted) {
       ScaffoldMessenger.of(

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -76,26 +76,7 @@ class FirestoreService {
     return snapshot.docs.isNotEmpty;
   }
 
-  /// Upsert stations by merging incoming stations with any existing
-  /// stations in the aggregate (e.g. manually added), then rebuilding.
-  /// Costs 1 read (aggregate doc) instead of N reads (individual docs).
-  static Future<void> upsertStations(List<Station> stations) async {
-    if (stations.isEmpty) return;
-
-    // Read existing aggregate (1 read) to preserve manually-added stations
-    final existing = await getStations();
-
-    // Index incoming stations by ID — Overpass data takes priority
-    final mergedById = {for (final s in existing) s.id: s};
-    for (final s in stations) {
-      mergedById[s.id] = s;
-    }
-
-    await _rebuildStationsAggregate(mergedById.values.toList());
-  }
-
   /// Rebuild the aggregate from the stations collection (N reads).
-  /// Use when Overpass is unavailable and the aggregate may be stale.
   static Future<void> rebuildStationsAggregate() => _rebuildStationsAggregate();
 
   /// Rebuild the stations aggregate doc.
@@ -118,6 +99,9 @@ class FirestoreService {
     }).toList();
   }
 
+  /// Rebuild the prices aggregate from the currentPrices collection.
+  static Future<void> rebuildPricesAggregate() => _rebuildPricesAggregate();
+
   /// Rebuild the prices aggregate doc.
   /// If [prices] is provided, uses them directly (0 reads).
   /// Otherwise falls back to reading all currentPrices docs from Firestore.
@@ -126,6 +110,32 @@ class FirestoreService {
 
     await _db.collection('aggregates').doc('prices').set({
       'prices': allPrices.map((p) => p.toJson()).toList(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  /// Update or insert a single price in the prices aggregate (1 read + 1 write).
+  static Future<void> _upsertPriceInAggregate(CurrentPrice price) async {
+    final aggDoc = await _db.collection('aggregates').doc('prices').get();
+    final list = aggDoc.exists
+        ? ((aggDoc.data()!['prices'] as List<dynamic>?) ?? [])
+            .map((e) => Map<String, dynamic>.from(e as Map))
+            .toList()
+        : <Map<String, dynamic>>[];
+
+    // Find existing entry by stationId + fuelType
+    final idx = list.indexWhere(
+      (p) => p['stationId'] == price.stationId && p['fuelType'] == price.fuelType.name,
+    );
+
+    if (idx != -1) {
+      list[idx] = price.toJson();
+    } else {
+      list.add(price.toJson());
+    }
+
+    await _db.collection('aggregates').doc('prices').set({
+      'prices': list,
       'updatedAt': FieldValue.serverTimestamp(),
     });
   }
@@ -257,8 +267,16 @@ class FirestoreService {
 
     await batch.commit();
 
-    // Rebuild prices aggregate so other users see updated prices
-    await _rebuildPricesAggregate();
+    // Update just the one price entry in the aggregate (1 read + 1 write)
+    // instead of rebuilding the entire aggregate from currentPrices (N reads).
+    final newPrice = CurrentPrice(
+      stationId: stationId,
+      fuelType: fuelType,
+      price: price,
+      updatedAt: now,
+      reportCount: currentCount + 1,
+    );
+    await _upsertPriceInAggregate(newPrice);
   }
 
   /// Returns the most recent report time for a user+station+fuelType combo,


### PR DESCRIPTION
This PR fixes the following:

- Removed Overpass as primary data source — app now reads directly from Firestore aggregates on startup (2 reads)
- Removed stale cache on cold startup so users always see latest data
- Fixed manually-added stations not appearing in the app
- Fixed Firestore `PERMISSION_DENIED` on Google sign-in by using `merge: true` for user profile writes
- Optimized price submission to update single entry in prices aggregate (1 read + 1 write) instead of full rebuild (N reads + 1 write)
- Simplified refresh to re-read aggregates (2 reads) instead of rebuilding from collections (N reads)