### PR TITLE
DRIV-118 - security fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.swp
 .buildlog/
 .history
-
+*.env
 
 
 # Flutter repo-specific

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,112 +2,136 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // ── Helper: check if user is admin ──
+    // ── Helpers ──────────────────────────────────────────────────
+    function isAppChecked() {
+      return request.appcheck.token != null;
+    }
+
     function isAdmin() {
       return request.auth != null
              && exists(/databases/$(database)/documents/users/$(request.auth.uid))
              && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
     }
 
+    function isSignedIn() {
+      return request.auth != null
+             && !request.auth.token.firebase.sign_in_provider.matches('anonymous');
+    }
+
     // ── Stations ──────────────────────────────────────────────────
-    // Anyone can read stations. Admins can write (for approving new stations).
+    // Anyone can read. Only admins can write (approve/edit/delete).
     match /stations/{stationId} {
       allow read: if true;
-      allow write: if isAdmin();
+      allow write: if isAppChecked() && isAdmin();
 
       // ── Price Reports (subcollection) ───────────────────────────
-      // Anyone can read reports.
-      // Only authenticated (non-anonymous) users can create reports.
-      // Admins can delete reports.
+      // Anyone can read. Authenticated non-anonymous users can create.
+      // Reports are immutable once created. Admins can delete.
       match /reports/{reportId} {
         allow read: if true;
-        allow create: if request.auth != null
-                      && !request.auth.token.firebase.sign_in_provider.matches('anonymous')
+        allow create: if isAppChecked()
+                      && isSignedIn()
                       && request.resource.data.userId == request.auth.uid
-                      && request.resource.data.keys().hasAll(['stationId', 'fuelType', 'price', 'userId', 'reportedAt'])
+                      && request.resource.data.stationId == stationId
+                      && request.resource.data.keys().hasAll(['id', 'stationId', 'fuelType', 'price', 'userId', 'reportedAt'])
                       && request.resource.data.price is number
                       && request.resource.data.price > 0
-                      && request.resource.data.price < 100;
+                      && request.resource.data.price < 100
+                      && request.resource.data.fuelType is string
+                      && request.resource.data.reportedAt is string;
         allow update: if false;
-        allow delete: if isAdmin();
+        allow delete: if isAppChecked() && isAdmin();
       }
     }
 
     // ── Current Prices ────────────────────────────────────────────
-    // Anyone can read current prices.
-    // Only authenticated (non-anonymous) users can update (via submitReport).
+    // Anyone can read. Authenticated non-anonymous users can create/update.
+    // Validates required fields and value ranges.
     match /currentPrices/{docId} {
       allow read: if true;
-      allow create, update: if request.auth != null
-                            && !request.auth.token.firebase.sign_in_provider.matches('anonymous');
+      allow create, update: if isAppChecked()
+                            && isSignedIn()
+                            && request.resource.data.keys().hasAll(['stationId', 'fuelType', 'price', 'updatedAt', 'reportCount'])
+                            && request.resource.data.price is number
+                            && request.resource.data.price > 0
+                            && request.resource.data.price < 100
+                            && request.resource.data.reportCount is int
+                            && request.resource.data.reportCount > 0;
       allow delete: if false;
     }
 
     // ── User Profiles ─────────────────────────────────────────────
-    // Users can read and write their own profile, but cannot set isAdmin.
-    // isAdmin is only settable via Firebase Console.
+    // Users can read/write their own profile. Cannot set isAdmin or
+    // trustScore from the client. reportCount can only increase by 1.
     match /users/{uid} {
       allow read: if request.auth != null && request.auth.uid == uid;
-      allow create: if request.auth != null
+      allow create: if isAppChecked()
+                    && request.auth != null
                     && request.auth.uid == uid
-                    && !request.resource.data.keys().hasAny(['isAdmin']);
-      allow update: if request.auth != null
+                    && !request.resource.data.keys().hasAny(['isAdmin', 'trustScore']);
+      allow update: if isAppChecked()
+                    && request.auth != null
                     && request.auth.uid == uid
-                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['isAdmin']);
-      allow delete: if request.auth != null && request.auth.uid == uid;
+                    && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['isAdmin', 'trustScore'])
+                    // reportCount can only go up by 1 at a time
+                    && (
+                      !request.resource.data.diff(resource.data).affectedKeys().hasAny(['reportCount'])
+                      || request.resource.data.reportCount == resource.data.reportCount + 1
+                    );
+      allow delete: if isAppChecked() && request.auth != null && request.auth.uid == uid;
     }
 
     // ── Bug Reports ───────────────────────────────────────────────
-    // Any authenticated user (including anonymous) can submit bug reports.
-    // No one can read or modify them from the client.
+    // Any authenticated user (including anonymous) can submit.
+    // No client reads or modifications.
     match /bug_reports/{reportId} {
-      allow create: if request.auth != null;
+      allow create: if isAppChecked() && request.auth != null;
       allow read, update, delete: if false;
     }
 
     // ── New Station Submissions ────────────────────────────────────
-    // Only authenticated (non-anonymous) users can submit new stations.
+    // Authenticated non-anonymous users can submit new stations.
     // Users can read/edit/delete their own pending submissions.
     // Users can mark feedback as read on any of their submissions.
     // Admins can read all and update status/feedback.
     match /new_stations/{docId} {
-      allow create: if request.auth != null
-                    && !request.auth.token.firebase.sign_in_provider.matches('anonymous')
+      allow create: if isAppChecked()
+                    && isSignedIn()
                     && request.resource.data.keys().hasAll(['name', 'brand', 'address', 'city', 'latitude', 'longitude', 'submittedBy', 'status'])
                     && request.resource.data.submittedBy == request.auth.uid
                     && request.resource.data.status == 'pending';
       allow read: if request.auth != null
                   && (resource.data.submittedBy == request.auth.uid || isAdmin());
-      allow update: if request.auth != null
+      allow update: if isAppChecked()
+                    && request.auth != null
                     && (
-                      // Admins can update any field (approve/reject/feedback)
                       isAdmin()
-                      // Users can mark feedback as read
                       || (resource.data.submittedBy == request.auth.uid
                           && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['feedbackRead']))
-                      // Users can edit own pending submissions
                       || (resource.data.submittedBy == request.auth.uid
                           && resource.data.status == 'pending'
                           && request.resource.data.submittedBy == request.auth.uid
                           && request.resource.data.status == 'pending')
                     );
-      allow delete: if request.auth != null
+      allow delete: if isAppChecked()
+                    && request.auth != null
                     && resource.data.submittedBy == request.auth.uid
                     && resource.data.status == 'pending';
     }
 
     // ── Station Modify Requests ─────────────────────────────────────
-    // Authenticated users can submit modify requests for existing stations.
+    // Authenticated non-anonymous users can submit modify requests.
     // Users can read their own requests and mark feedback as read.
     // Admins can read all and approve/reject.
     match /station_modify_requests/{docId} {
-      allow create: if request.auth != null
-                    && !request.auth.token.firebase.sign_in_provider.matches('anonymous')
+      allow create: if isAppChecked()
+                    && isSignedIn()
                     && request.resource.data.submittedBy == request.auth.uid
                     && request.resource.data.status == 'pending';
       allow read: if request.auth != null
                   && (resource.data.submittedBy == request.auth.uid || isAdmin());
-      allow update: if request.auth != null
+      allow update: if isAppChecked()
+                    && request.auth != null
                     && (
                       isAdmin()
                       || (resource.data.submittedBy == request.auth.uid
@@ -117,11 +141,14 @@ service cloud.firestore {
     }
 
     // ── Aggregates ─────────────────────────────────────────────────
-    // Anyone can read aggregate docs (stations + prices in single docs).
-    // Writes happen from client after upsert/submit — allow for authed users.
+    // Anyone can read. Only admins can write the stations aggregate.
+    // Authenticated non-anonymous users can write the prices aggregate
+    // (updated after each price submission).
     match /aggregates/{docId} {
       allow read: if true;
-      allow write: if request.auth != null;
+      allow write: if isAppChecked()
+                   && ((docId == 'prices' && isSignedIn())
+                       || (docId == 'stations' && isAdmin()));
     }
 
     // ── Deny everything else ──────────────────────────────────────

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,10 +42,10 @@ void main() async {
   }
 
   await FirebaseAppCheck.instance.activate(
-    androidProvider:
-        kDebugMode ? AndroidProvider.debug : AndroidProvider.playIntegrity,
-    appleProvider:
-        kDebugMode ? AppleProvider.debug : AppleProvider.deviceCheck,
+    androidProvider: kDebugMode
+        ? AndroidProvider.debug
+        : AndroidProvider.playIntegrity,
+    appleProvider: kDebugMode ? AppleProvider.debug : AppleProvider.deviceCheck,
   );
 
   FirebaseFirestore.instance.settings = const Settings(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,9 @@
 */
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:provider/provider.dart';
@@ -38,6 +40,14 @@ void main() async {
   } catch (_) {
     // Already initialized (e.g. after hot restart)
   }
+
+  await FirebaseAppCheck.instance.activate(
+    androidProvider:
+        kDebugMode ? AndroidProvider.debug : AndroidProvider.playIntegrity,
+    appleProvider:
+        kDebugMode ? AppleProvider.debug : AppleProvider.deviceCheck,
+  );
+
   FirebaseFirestore.instance.settings = const Settings(
     persistenceEnabled: false,
   );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import cloud_firestore
 import connectivity_plus
 import device_info_plus
 import file_selector_macos
+import firebase_app_check
 import firebase_auth
 import firebase_core
 import geolocator_apple
@@ -22,6 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FLTFirebaseAppCheckPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAppCheckPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: f698de6eb8a0dd7a9a931bbfe13568e8b77e702eb2deb13dd83480c5373e7746
+      sha256: ff0a84a2734d9e1089f8aedd5c0af0061b82fb94e95260d943404e0ef2134b11
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.68"
+    version: "1.3.59"
   animated_stack_widget:
     dependency: transitive
     description:
@@ -85,26 +85,26 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: "2e0a07b9905375fa17fba82ee1cd70df592907691e2f25a629823a021e49c1a2"
+      sha256: "2d33da4465bdb81b6685c41b535895065adcb16261beb398f5f3bbc623979e9c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "5.6.12"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: b82a35eb6a1bde9569df372f933fc5a01bcddef58c993d78f78c31d111fcd080
+      sha256: "413c4e01895cf9cb3de36fa5c219479e06cd4722876274ace5dfc9f13ab2e39b"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "6.6.12"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: "96bb9aec40d026b88737c1c426972ec435cac6b8d0f21af8eebb84fc09f100da"
+      sha256: c1e30fc4a0fcedb08723fb4b1f12ee4e56d937cbf9deae1bda43cbb6367bb4cf
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "4.4.12"
   code_assets:
     dependency: transitive
     description:
@@ -281,38 +281,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+5"
+  firebase_app_check:
+    dependency: "direct main"
+    description:
+      name: firebase_app_check
+      sha256: c4124632094a4062d7a1ff0a9f9c657ff54bece5d8393af4626cb191351a2aac
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2+10"
+  firebase_app_check_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_app_check_platform_interface
+      sha256: "4ca80bcc6c5c55289514d85e7c8ba8bc354342d23ab807b01c3f82e2fc7158e4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1+10"
+  firebase_app_check_web:
+    dependency: transitive
+    description:
+      name: firebase_app_check_web
+      sha256: b3150a78fe18c27525af05b149724ee33bd8592a5959e484fdfa5c98e25edb5f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0+14"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: "7421650001840aa63d3e7a59062bfa1a53febc52c7520e1effad0d325d6469cb"
+      sha256: "0fed2133bee1369ee1118c1fef27b2ce0d84c54b7819a2b17dada5cfec3b03ff"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "5.7.0"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: "4f9103fe33f5a8cbe7b9bdae7a76e01cb67026b3fcaac5cf603a23685213f7cf"
+      sha256: "871c9df4ec9a754d1a793f7eb42fa3b94249d464cfb19152ba93e14a5966b386"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.8"
+    version: "7.7.3"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: "4173bfa41a8b6f0a791af99c61bead53fca819e32237c9336b84ebfbce44d7ae"
+      sha256: d9ada769c43261fd1b18decf113186e915c921a811bd5014f5ea08f4cf4bc57e
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "5.15.3"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "2f988dab915efde3b3105268dbd69efce0e8570d767a218ccd914afd0c10c8cc"
+      sha256: "7be63a3f841fc9663342f7f3a011a42aef6a61066943c90b1c434d79d5c995c5"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "3.15.2"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -325,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "1399ab1f0ac3b503d8a9be64a4c997fc066bbf33f701f42866e5569f26205ebe"
+      sha256: "0ed0dc292e8f9ac50992e2394e9d336a0275b6ae400d64163fdf0a8a8b556c37"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.1"
+    version: "2.24.1"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,9 +35,10 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  firebase_core: ^4.6.0
-  cloud_firestore: ^6.2.0
-  firebase_auth: ^6.3.0
+  firebase_core: ^3.12.1
+  cloud_firestore: ^5.6.5
+  firebase_auth: ^5.5.1
+  firebase_app_check: ^0.3.2+10
   flutter_map: ^8.2.2
   latlong2: ^0.9.1
   geolocator: ^14.0.2


### PR DESCRIPTION
This PR adds Appcheck and other small security fixes:


- Add firebase_app_check with Play Integrity (Android) and DeviceCheck (iOS) to verify requests come from the genuine app binary                             
- Add isAppChecked() guard to all Firestore write rules — requests without a valid App Check token are rejected
- Add field validation on currentPrices writes (required fields, price range 0-100, positive reportCount)                                                    
- Restrict aggregates/stations writes to admin-only (was any authenticated user)                                                                             
- Restrict aggregates/prices writes to signed-in non-anonymous users (was any authenticated user including anonymous)                                        
- Block client-side writes to trustScore on user profiles (admin-only field)                                                                                 
- Enforce reportCount can only increment by 1 per update (prevents inflation)                                                                                
- Validate stationId in price reports matches the parent document path (prevents cross-station injection)                                                    
- Add isSignedIn() helper to DRY up anonymous-check logic across all rules                                                                                   
- Debug providers enabled in debug mode so local development still works      