### PR TITLE
DRIV-0 - automate build number using git commit count

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,7 @@ jobs:
   build-and-test:
     name: Build & Run Tests
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[release]')"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,9 @@ jobs:
 
       - name: Compute build number from commit count
         id: build_number
+        # +1 accounts for the pubspec update commit at the end of this workflow
         run: |
-          BUILD=$(git rev-list --count HEAD)
+          BUILD=$(( $(git rev-list --count HEAD) + 1 ))
           echo "value=$BUILD" >> "$GITHUB_OUTPUT"
           echo "Build number: $BUILD"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,19 +18,25 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
-      - name: Compute build number
+      - name: Compute build number from commit count
         id: build_number
         run: |
-          # Get the highest build number from existing tags (v*+N)
-          LATEST=$(git tag -l 'v*+*' | sed 's/.*+//' | sort -n | tail -1)
-          NEXT=$(( ${LATEST:-0} + 1 ))
-          echo "value=$NEXT" >> "$GITHUB_OUTPUT"
-          echo "Build number: $NEXT (previous: ${LATEST:-none})"
+          BUILD=$(git rev-list --count HEAD)
+          echo "value=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "Build number: $BUILD"
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -79,3 +85,14 @@ jobs:
             build/app/outputs/flutter-apk/app-release.apk
             build/app/outputs/bundle/release/app-release.aab
           generate_release_notes: true
+
+      - name: Update pubspec.yaml version
+        run: |
+          NEW_VERSION="${{ inputs.version }}+${{ steps.build_number.outputs.value }}"
+          sed -i "s/^version: .*$/version: ${NEW_VERSION}/" pubspec.yaml
+          git config user.name "drivstoffpriser-bot[bot]"
+          git config user.email "drivstoffpriser-bot[bot]@users.noreply.github.com"
+          git add pubspec.yaml
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: release ${NEW_VERSION} [release]"
+          git push

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ license: GPL-3.0
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.6+2
 
 environment:
   sdk: ^3.10.8

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Build iOS IPA with build number derived from git commit count.
+# This ensures the build number is always increasing and matches
+# the same scheme used by CI for Android builds.
+
+set -euo pipefail
+
+BUILD_NUMBER=$(git rev-list --count HEAD)
+VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
+
+echo "Building iOS: version=$VERSION build=$BUILD_NUMBER"
+flutter build ipa --build-name="$VERSION" --build-number="$BUILD_NUMBER" "$@"


### PR DESCRIPTION
pubspec.yaml version was stale (1.0.0+1) while the latest release was v1.0.6+2.
Build numbers were computed from git tags in the release workflow, which was fragile and left pubspec out of sync.

With this change build numbers are derived from `git rev-list --count HEAD` — always increasing, deterministic, and works for both Android and iOS without extra commits. The release workflow updates pubspec.yaml after each release so the repo reflects the current version.

Play Store requires that versionCode is an ever increasing integer, so using a build number that resets on each version bump would not work. Simply always increasing the build number instead fixes this, and works for IOS release process as well.

IOS builds also relies on pubspec.yaml by default, but when releasing locally it should also derive the actual build number based on commit history, so a script is added to make that easier to remember.

Changes:
- pubspec.yaml: update version to 1.0.6+2 (match latest release)
- release.yml: use commit count for build number, commit version update to pubspec after release using GitHub App token
- build-and-test.yml: skip CI on [release] bot commits
- scripts/build_ios.sh: local iOS build script using same commit count scheme for TestFlight uploads