### PR TITLE
DRIV-0 - Fix heart favorite bug

### DIFF
--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -147,6 +147,10 @@ class StationProvider extends ChangeNotifier {
       result = result.where((s) => _selectedBrands.contains(s.brand));
     }
 
+    if (_showFavoritesOnly) {
+      result = result.where((s) => _favoriteStationIds.contains(s.id));
+    }
+
     return result.toList();
   }
 

--- a/lib/screens/map/widgets/fuel_filter_bar.dart
+++ b/lib/screens/map/widgets/fuel_filter_bar.dart
@@ -52,28 +52,44 @@ class FuelFilterBar extends StatelessWidget {
                     ),
                   );
                 }),
-                if (provider.favoriteStationIds.isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.only(left: 4),
-                    child: GestureDetector(
-                      onTap: () => provider.setShowFavoritesOnly(
-                        !provider.showFavoritesOnly,
-                      ),
-                      child: Icon(
-                        provider.showFavoritesOnly
-                            ? Icons.favorite
-                            : Icons.favorite_border,
-                        size: 20,
-                        color: provider.showFavoritesOnly
-                            ? Colors.red
-                            : AppColors.textMuted(context),
-                      ),
-                    ),
-                  ),
               ],
             ),
           ),
         ),
+        if (provider.favoriteStationIds.isNotEmpty)
+          Padding(
+            padding: EdgeInsets.only(right: trailing != null ? 8 : 16),
+            child: GestureDetector(
+              onTap: () => provider.setShowFavoritesOnly(
+                !provider.showFavoritesOnly,
+              ),
+              child: Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: provider.showFavoritesOnly
+                        ? Colors.red
+                        : AppColors.border(context),
+                    width: 0.5,
+                  ),
+                ),
+                child: Center(
+                  child: Icon(
+                    provider.showFavoritesOnly
+                        ? Icons.favorite
+                        : Icons.favorite_border,
+                    size: 18,
+                    color: provider.showFavoritesOnly
+                        ? Colors.red
+                        : AppColors.textMuted(context),
+                  ),
+                ),
+              ),
+            ),
+          ),
         if (trailing != null)
           Padding(padding: const EdgeInsets.only(right: 16), child: trailing!),
       ],

--- a/lib/screens/map/widgets/fuel_filter_bar.dart
+++ b/lib/screens/map/widgets/fuel_filter_bar.dart
@@ -60,9 +60,8 @@ class FuelFilterBar extends StatelessWidget {
           Padding(
             padding: EdgeInsets.only(right: trailing != null ? 8 : 16),
             child: GestureDetector(
-              onTap: () => provider.setShowFavoritesOnly(
-                !provider.showFavoritesOnly,
-              ),
+              onTap: () =>
+                  provider.setShowFavoritesOnly(!provider.showFavoritesOnly),
               child: Container(
                 width: 32,
                 height: 32,

--- a/lib/screens/station_detail/station_list_screen.dart
+++ b/lib/screens/station_detail/station_list_screen.dart
@@ -58,35 +58,9 @@ class StationListScreen extends StatelessWidget {
       body: Column(
         children: [
           FuelFilterBar(
-            trailing: Consumer<StationProvider>(
-              builder: (context, provider, _) {
-                final hasFavorites = provider.favoriteStationIds.isNotEmpty;
-                return Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (hasFavorites)
-                      GestureDetector(
-                        onTap: () => provider.setShowFavoritesOnly(
-                          !provider.showFavoritesOnly,
-                        ),
-                        child: Icon(
-                          provider.showFavoritesOnly
-                              ? Icons.favorite
-                              : Icons.favorite_border,
-                          size: 18,
-                          color: provider.showFavoritesOnly
-                              ? Colors.red
-                              : AppColors.textPrimary(context),
-                        ),
-                      ),
-                    if (hasFavorites) const SizedBox(width: 8),
-                    const BrandFilterButton(
-                      heroTag: 'brandFilterList',
-                      filterLocation: FilterLocation.list,
-                    ),
-                  ],
-                );
-              },
+            trailing: const BrandFilterButton(
+              heroTag: 'brandFilterList',
+              filterLocation: FilterLocation.list,
             ),
           ),
           Padding(


### PR DESCRIPTION
Fixes som issues with the heart/favorite feature:
- Two hearts were being shown on the stations screen (now 1)
- Filtering based on favorite only worked on map (now works on stations screen too)
- Add a box around heart so that it is easier to see with map background


<img width="1284" height="2778" alt="Simulator Screenshot - iPhone 14 Plus - 2026-04-04 at 09 44 18" src="https://github.com/user-attachments/assets/9e3a8c2a-e6e0-4391-b222-3e4658e3d464" />
<img width="1284" height="2778" alt="Simulator Screenshot - iPhone 14 Plus - 2026-04-04 at 09 44 27" src="https://github.com/user-attachments/assets/4eee9406-d103-4e8b-a959-d75f7b19303d" />


