### PR TITLE
DRIV-0 - Add email verification

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -185,6 +185,7 @@
   "googleEmailAccount": "Google + Email account",
   "googleAccount": "Google account",
   "emailAccount": "Email account",
+  "emailConfirmed": "Email confirmed",
 
   "contributeData": "CONTRIBUTE DATA",
   "station": "Station",
@@ -322,5 +323,9 @@
   "@onboardingStepOf": { "placeholders": { "current": { "type": "int" }, "total": { "type": "int" } } },
 
   "nearbyStationPrompt": "Looks like you are close to {stationName}. Report a price?",
-  "@nearbyStationPrompt": { "placeholders": { "stationName": { "type": "String" } } }
+  "@nearbyStationPrompt": { "placeholders": { "stationName": { "type": "String" } } },
+  "emailNotVerified": "Verify your email",
+  "emailNotVerifiedSubtitle": "Check your inbox for a verification link",
+  "resendVerificationEmail": "Resend email",
+  "verificationEmailSent": "Verification email sent"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1028,6 +1028,12 @@ abstract class AppLocalizations {
   /// **'Email account'**
   String get emailAccount;
 
+  /// No description provided for @emailConfirmed.
+  ///
+  /// In en, this message translates to:
+  /// **'Email confirmed'**
+  String get emailConfirmed;
+
   /// No description provided for @contributeData.
   ///
   /// In en, this message translates to:
@@ -1705,6 +1711,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Looks like you are close to {stationName}. Report a price?'**
   String nearbyStationPrompt(String stationName);
+
+  /// No description provided for @emailNotVerified.
+  ///
+  /// In en, this message translates to:
+  /// **'Verify your email'**
+  String get emailNotVerified;
+
+  /// No description provided for @emailNotVerifiedSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Check your inbox for a verification link'**
+  String get emailNotVerifiedSubtitle;
+
+  /// No description provided for @resendVerificationEmail.
+  ///
+  /// In en, this message translates to:
+  /// **'Resend email'**
+  String get resendVerificationEmail;
+
+  /// No description provided for @verificationEmailSent.
+  ///
+  /// In en, this message translates to:
+  /// **'Verification email sent'**
+  String get verificationEmailSent;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -512,6 +513,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get emailAccount => 'Email account';
 
   @override
+  String get emailConfirmed => 'Email confirmed';
+
+  @override
   String get contributeData => 'CONTRIBUTE DATA';
 
   @override
@@ -887,4 +891,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String nearbyStationPrompt(String stationName) {
     return 'Looks like you are close to $stationName. Report a price?';
   }
+
+  String get emailNotVerified => 'Verify your email';
+
+  @override
+  String get emailNotVerifiedSubtitle =>
+      'Check your inbox for a verification link';
+
+  @override
+  String get resendVerificationEmail => 'Resend email';
+
+  @override
+  String get verificationEmailSent => 'Verification email sent';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -515,6 +516,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get emailAccount => 'E-postkonto';
 
   @override
+  String get emailConfirmed => 'E-post bekreftet';
+
+  @override
   String get contributeData => 'BIDRA MED DATA';
 
   @override
@@ -893,4 +897,16 @@ class AppLocalizationsNb extends AppLocalizations {
   String nearbyStationPrompt(String stationName) {
     return 'Du er i nærheten av $stationName. Rapportere pris?';
   }
+
+  String get emailNotVerified => 'Bekreft e-posten din';
+
+  @override
+  String get emailNotVerifiedSubtitle =>
+      'Sjekk innboksen din for en bekreftelseslenke';
+
+  @override
+  String get resendVerificationEmail => 'Send på nytt';
+
+  @override
+  String get verificationEmailSent => 'Bekreftelses-e-post sendt';
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -172,6 +172,7 @@
   "googleEmailAccount": "Google + E-postkonto",
   "googleAccount": "Google-konto",
   "emailAccount": "E-postkonto",
+  "emailConfirmed": "E-post bekreftet",
 
   "contributeData": "BIDRA MED DATA",
   "station": "Stasjon",
@@ -299,5 +300,9 @@
   "@onboardingStepOf": { "placeholders": { "current": { "type": "int" }, "total": { "type": "int" } } },
 
   "nearbyStationPrompt": "Du er i nærheten av {stationName}. Rapportere pris?",
-  "@nearbyStationPrompt": { "placeholders": { "stationName": { "type": "String" } } }
+  "@nearbyStationPrompt": { "placeholders": { "stationName": { "type": "String" } } },
+  "emailNotVerified": "Bekreft e-posten din",
+  "emailNotVerifiedSubtitle": "Sjekk innboksen din for en bekreftelseslenke",
+  "resendVerificationEmail": "Send på nytt",
+  "verificationEmailSent": "Bekreftelses-e-post sendt"
 }

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -173,6 +173,31 @@ class UserProvider extends ChangeNotifier {
       );
     }
     await FirestoreService.setUserProfile(_user);
+    try {
+      await _auth.currentUser?.sendEmailVerification();
+    } catch (_) {}
+    notifyListeners();
+  }
+
+  /// True when the user has linked an email/password credential.
+  bool get hasEmailProvider =>
+      _auth.currentUser?.providerData.any((i) => i.providerId == 'password') ??
+      false;
+
+  /// The current user's email address, if any.
+  String? get email => _auth.currentUser?.email;
+
+  /// Whether the current user's email has been verified.
+  bool get isEmailVerified => _auth.currentUser?.emailVerified ?? false;
+
+  /// Re-send the verification email.
+  Future<void> sendVerificationEmail() async {
+    await _auth.currentUser?.sendEmailVerification();
+  }
+
+  /// Reload the Firebase user to pick up email-verified status, etc.
+  Future<void> reloadUser() async {
+    await _auth.currentUser?.reload();
     notifyListeners();
   }
 

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -41,19 +41,27 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _isRefreshing = false;
+  bool _isResendingEmail = false;
   int _stationSubmissionCount = 0;
-  bool _hasLoadedCount = false;
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final userProvider = context.read<UserProvider>();
+      if (userProvider.isAuthenticated) {
+        _loadSubmissionCount();
+      }
+    });
+  }
 
   Future<void> _loadSubmissionCount() async {
     final userProvider = context.read<UserProvider>();
-    if (!userProvider.isAuthenticated) return;
     final submissions = await FirestoreService.getUserStationSubmissions(
       userProvider.user.id,
     );
     if (mounted) {
       setState(() {
         _stationSubmissionCount = submissions.length;
-        _hasLoadedCount = true;
       });
     }
   }
@@ -62,8 +70,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _isRefreshing = true);
 
     final stationProvider = context.read<StationProvider>();
+    final userProvider = context.read<UserProvider>();
     try {
-      await stationProvider.refreshStations();
+      await Future.wait([
+        stationProvider.refreshStations(),
+        userProvider.reloadUser(),
+      ]);
       if (mounted) {
         ScaffoldMessenger.of(
           context,
@@ -87,10 +99,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final isAuth = userProvider.isAuthenticated;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final activeColor = AppColors.primaryContainer(context);
-
-    if (isAuth && !_hasLoadedCount) {
-      _loadSubmissionCount();
-    }
 
     return Scaffold(
       backgroundColor: AppColors.background(context),
@@ -125,6 +133,89 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     isAuthenticated: isAuth,
                     userProvider: userProvider,
                   ),
+
+                  // ── Email Verification Banner ──
+                  if (isAuth &&
+                      userProvider.hasEmailProvider &&
+                      !userProvider.isEmailVerified) ...[
+                    const SizedBox(height: 16),
+                    Container(
+                      padding: const EdgeInsets.all(14),
+                      decoration: BoxDecoration(
+                        color: isDark
+                            ? Colors.orange.withValues(alpha: 0.15)
+                            : Colors.orange.withValues(alpha: 0.08),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: Colors.orange.withValues(alpha: 0.3),
+                          width: 0.5,
+                        ),
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.mark_email_unread_outlined,
+                            color: Colors.orange,
+                            size: 22,
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  context.l10n.emailNotVerified,
+                                  style: AppTextStyles.bodyMedium(context),
+                                ),
+                                const SizedBox(height: 2),
+                                Text(
+                                  context.l10n.emailNotVerifiedSubtitle,
+                                  style: AppTextStyles.label(context),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          TextButton(
+                            onPressed: _isResendingEmail
+                                ? null
+                                : () async {
+                                    setState(() => _isResendingEmail = true);
+                                    try {
+                                      await userProvider
+                                          .sendVerificationEmail();
+                                      if (!context.mounted) return;
+                                      ScaffoldMessenger.of(
+                                        context,
+                                      ).showSnackBar(
+                                        SnackBar(
+                                          content: Text(
+                                            context.l10n.verificationEmailSent,
+                                          ),
+                                        ),
+                                      );
+                                    } catch (e) {
+                                      if (!context.mounted) return;
+                                      ScaffoldMessenger.of(
+                                        context,
+                                      ).showSnackBar(
+                                        SnackBar(content: Text(e.toString())),
+                                      );
+                                    } finally {
+                                      if (mounted) {
+                                        setState(
+                                          () => _isResendingEmail = false,
+                                        );
+                                      }
+                                    }
+                                  },
+                            child: Text(context.l10n.resendVerificationEmail),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+
                   const SizedBox(height: 20),
 
                   // ── Contributions Card ──
@@ -207,7 +298,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                         context,
                                         AppRoutes.myStationSubmissions,
                                       );
-                                      _hasLoadedCount = false;
                                       _loadSubmissionCount();
                                     },
                                     child: Container(
@@ -676,14 +766,15 @@ class _ProfileHero extends StatelessWidget {
                     borderRadius: BorderRadius.circular(6),
                   ),
                   child: Text(
-                    switch (userProvider.accountType) {
-                      AccountType.anonymous =>
-                        context.l10n.anonymousBrowsingOnly,
-                      AccountType.email => context.l10n.emailAccount,
-                      AccountType.google => context.l10n.googleAccount,
-                      AccountType.googleEmail =>
-                        context.l10n.googleEmailAccount,
-                    },
+                    userProvider.email ??
+                        switch (userProvider.accountType) {
+                          AccountType.anonymous =>
+                            context.l10n.anonymousBrowsingOnly,
+                          AccountType.email => context.l10n.emailAccount,
+                          AccountType.google => context.l10n.googleAccount,
+                          AccountType.googleEmail =>
+                            context.l10n.googleEmailAccount,
+                        },
                     style: TextStyle(
                       fontSize: 11,
                       fontWeight: FontWeight.w500,
@@ -691,8 +782,27 @@ class _ProfileHero extends StatelessWidget {
                           ? activeColor
                           : AppColors.textMuted(context),
                     ),
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
+                if (userProvider.isEmailVerified) ...[
+                  const SizedBox(height: 4),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.verified, size: 13, color: activeColor),
+                      const SizedBox(width: 4),
+                      Text(
+                        context.l10n.emailConfirmed,
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w500,
+                          color: activeColor,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
                 if (isAuthenticated) ...[
                   const SizedBox(height: 8),
                   Row(
@@ -704,7 +814,7 @@ class _ProfileHero extends StatelessWidget {
                       ),
                       const SizedBox(width: 12),
                       _StatBadge(
-                        icon: Icons.verified,
+                        icon: Icons.groups,
                         value: '${(user.trustScore * 100).toStringAsFixed(0)}%',
                         label: context.l10n.trust,
                       ),

--- a/lib/widgets/floating_pill_nav.dart
+++ b/lib/widgets/floating_pill_nav.dart
@@ -255,7 +255,10 @@ class _FloatingPillNavState extends State<FloatingPillNav> {
                             activeIcon: Icons.person,
                             label: context.l10n.navProfile,
                             isActive: _currentIndex == 2,
-                            onTap: () => setState(() => _currentIndex = 2),
+                            onTap: () {
+                              setState(() => _currentIndex = 2);
+                              context.read<UserProvider>().reloadUser();
+                            },
                           ),
                         ],
                       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -817,10 +817,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1134,10 +1134,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   timeago:
     dependency: "direct main"
     description:


### PR DESCRIPTION
We should verify emails to lessen the risk of people creating fake adresses, claiming other peoples addresses, and spamming fake data.

This adds the following functionality:
- Sends email verification link on registration
- Adds banner if unverified to resend email
- Show actual email address on profile page instead of just "E-postbruker"
- Adds refresh of user data when navigating to profile page
- Shows "E-post bekreftet" on profile if verified
- (and changes icon of trust score so that it doesn't conflict with verified icon)

We still don't require the email to be verified to register prices, but we should use the data in the backend
to differentiate between verified users and not.

Alternatively we can ditch password registration all together, and just move to magic links for login (my preference).


<img width="830" height="1678" alt="bilde" src="https://github.com/user-attachments/assets/6d5aec39-1174-4b0b-8c21-5ddf28c33e11" />
<img width="830" height="1678" alt="bilde" src="https://github.com/user-attachments/assets/c61b2975-81d0-4b4a-a63a-46aa2e5c06c1" />
