### PR TITLE
DRIV-0 - Use new backend and update station detail screen

### DIFF
--- a/lib/models/current_price.dart
+++ b/lib/models/current_price.dart
@@ -43,6 +43,19 @@ class CurrentPrice {
     );
   }
 
+  factory CurrentPrice.fromBackendJson(
+    String stationId,
+    Map<String, dynamic> json,
+  ) {
+    return CurrentPrice(
+      stationId: stationId,
+      fuelType: FuelType.fromBackendString(json['fuelType'] as String),
+      price: double.parse(json['price'] as String),
+      updatedAt: DateTime.parse(json['registeredAt'] as String),
+      reportCount: 0,
+    );
+  }
+
   Map<String, dynamic> toJson() {
     return {
       'stationId': stationId,

--- a/lib/models/fuel_type.dart
+++ b/lib/models/fuel_type.dart
@@ -43,4 +43,17 @@ enum FuelType {
   };
 
   String get unit => 'L';
+
+  String get backendString => switch (this) {
+    FuelType.petrol95 => 'GASOLINE_95',
+    FuelType.petrol98 => 'GASOLINE_98',
+    FuelType.diesel => 'DIESEL',
+  };
+
+  static FuelType fromBackendString(String s) => switch (s) {
+    'GASOLINE_95' => FuelType.petrol95,
+    'GASOLINE_98' => FuelType.petrol98,
+    'DIESEL' => FuelType.diesel,
+    _ => throw ArgumentError('Unknown backend fuel type: $s'),
+  };
 }

--- a/lib/models/station.dart
+++ b/lib/models/station.dart
@@ -16,6 +16,26 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import 'current_price.dart';
+import 'fuel_type.dart';
+
+const _providerToDisplayName = {
+  'AUTOMAT_1': 'Automat1',
+  'BEST': 'Best',
+  'BUNKER_OIL': 'Bunker Oil',
+  'CIRCLE_K': 'Circle K',
+  'DRIV': 'Driv',
+  'ESSO': 'Esso',
+  'HALTBAKK_EXPRESS': 'Haltbakk Express',
+  'OLJELEVERANDØREN': 'Oljeleverandøren',
+  'ST1': 'St1',
+  'TANKEN': 'Tanken',
+  'TRONDER_OIL': 'Trønder Oil',
+  'UNO_X': 'Uno-X',
+  'YX': 'YX',
+  'YX_TRUCK': 'YX Truck',
+};
+
 class Station {
   final String id;
   final String name;
@@ -24,6 +44,7 @@ class Station {
   final String city;
   final double latitude;
   final double longitude;
+  final Map<FuelType, CurrentPrice> prices;
 
   const Station({
     required this.id,
@@ -33,9 +54,16 @@ class Station {
     required this.city,
     required this.latitude,
     required this.longitude,
+    this.prices = const {},
   });
 
   factory Station.fromJson(Map<String, dynamic> json) {
+    final rawPrices = json['prices'] as List<dynamic>? ?? [];
+    final prices = <FuelType, CurrentPrice>{};
+    for (final p in rawPrices) {
+      final price = CurrentPrice.fromJson(p as Map<String, dynamic>);
+      prices[price.fuelType] = price;
+    }
     return Station(
       id: json['id'] as String,
       name: json['name'] as String,
@@ -44,6 +72,32 @@ class Station {
       city: json['city'] as String,
       latitude: (json['latitude'] as num).toDouble(),
       longitude: (json['longitude'] as num).toDouble(),
+      prices: prices,
+    );
+  }
+
+  factory Station.fromBackendJson(Map<String, dynamic> json) {
+    final provider = json['provider'] as String;
+    final location = json['location'] as Map<String, dynamic>;
+    final stationId = json['id'] as String;
+    final rawPrices = json['prices'] as List<dynamic>? ?? [];
+    final prices = <FuelType, CurrentPrice>{};
+    for (final p in rawPrices) {
+      final price = CurrentPrice.fromBackendJson(
+        stationId,
+        p as Map<String, dynamic>,
+      );
+      prices[price.fuelType] = price;
+    }
+    return Station(
+      id: stationId,
+      name: json['name'] as String,
+      brand: _providerToDisplayName[provider] ?? provider,
+      address: json['address'] as String,
+      city: json['city'] as String,
+      latitude: (location['lat'] as num).toDouble(),
+      longitude: (location['lng'] as num).toDouble(),
+      prices: prices,
     );
   }
 
@@ -56,6 +110,7 @@ class Station {
       'city': city,
       'latitude': latitude,
       'longitude': longitude,
+      'prices': prices.values.map((p) => p.toJson()).toList(),
     };
   }
 }

--- a/lib/providers/price_provider.dart
+++ b/lib/providers/price_provider.dart
@@ -17,18 +17,19 @@
 */
 
 import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/fuel_type.dart';
 import '../models/price_history_point.dart';
 import '../models/price_report.dart';
-import '../services/firestore_service.dart';
+import '../services/backend_api_client.dart';
 
 class PriceProvider extends ChangeNotifier {
   static const Duration cooldownDuration = Duration(hours: 1);
 
   List<PriceReport> _reports = [];
   Map<FuelType, List<PriceHistoryPoint>> _history = {};
-  bool _isLoading = false;
+  final bool _isLoading = false;
   bool _isSubmitting = false;
   bool _isLoadingHistory = false;
   String? _error;
@@ -40,20 +41,27 @@ class PriceProvider extends ChangeNotifier {
   bool get isLoadingHistory => _isLoadingHistory;
   String? get error => _error;
 
-  Future<void> loadReports(String stationId) async {
-    _isLoading = true;
-    notifyListeners();
-
-    _reports = await FirestoreService.getReports(stationId);
-    _isLoading = false;
+  void clear() {
+    _reports = [];
+    _history = {};
+    _error = null;
     notifyListeners();
   }
 
   Future<void> loadHistory(String stationId) async {
+    _history = {};
+    _reports = [];
     _isLoadingHistory = true;
     notifyListeners();
 
-    _history = await FirestoreService.getPriceHistory(stationId);
+    try {
+      final result = await BackendApiClient().getPriceHistory(stationId);
+      _history = result.history;
+      _reports = result.recentUpdates;
+    } catch (e, st) {
+      debugPrint('loadHistory error: $e\n$st');
+      _history = {};
+    }
     _isLoadingHistory = false;
     notifyListeners();
   }
@@ -64,11 +72,12 @@ class PriceProvider extends ChangeNotifier {
     required String stationId,
     required FuelType fuelType,
   }) async {
-    final lastReport = await FirestoreService.getLastReportTime(
-      userId: userId,
-      stationId: stationId,
-      fuelType: fuelType,
-    );
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'lastReport_${stationId}_${fuelType.name}';
+    final stored = prefs.getString(key);
+    if (stored == null) return null;
+
+    final lastReport = DateTime.tryParse(stored);
     if (lastReport == null) return null;
 
     final elapsed = DateTime.now().difference(lastReport);
@@ -89,13 +98,15 @@ class PriceProvider extends ChangeNotifier {
     notifyListeners();
 
     try {
-      await FirestoreService.submitReport(
-        stationId: stationId,
-        fuelType: fuelType,
-        price: price,
-        userId: userId,
-        incrementUserReport: incrementUserReport,
-      );
+      final client = BackendApiClient();
+      await client.registerPrices(stationId, [
+        (fuelType: fuelType, price: price),
+      ]);
+
+      final prefs = await SharedPreferences.getInstance();
+      final key = 'lastReport_${stationId}_${fuelType.name}';
+      await prefs.setString(key, DateTime.now().toIso8601String());
+
       _isSubmitting = false;
       notifyListeners();
       return true;

--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -18,9 +18,9 @@
 
 import 'package:flutter/foundation.dart';
 
-import '../models/current_price.dart';
 import '../models/fuel_type.dart';
 import '../models/station.dart';
+import '../services/backend_api_client.dart';
 import '../services/cache_service.dart';
 import '../services/distance_service.dart';
 import '../services/favorite_service.dart';
@@ -31,7 +31,10 @@ enum SortMode { cheapest, nearest, latest }
 
 class StationProvider extends ChangeNotifier {
   List<Station> _stations = [];
-  List<CurrentPrice> _prices = [];
+
+  // Separate state for the map view, populated by bbox fetches.
+  List<Station> _mapStations = [];
+  String? _bestMapStationId;
   FuelType _selectedFuelType = FuelType.petrol95;
   SortMode _sortMode = SortMode.cheapest;
   Set<String> _selectedBrands = {};
@@ -49,7 +52,6 @@ class StationProvider extends ChangeNotifier {
   double? _userLng;
 
   List<Station> get stations => _stations;
-  List<CurrentPrice> get prices => _prices;
   FuelType get selectedFuelType => _selectedFuelType;
   SortMode get sortMode => _sortMode;
   Set<String> get selectedBrands => _selectedBrands;
@@ -78,13 +80,29 @@ class StationProvider extends ChangeNotifier {
   }
 
   Future<void> toggleFavorite(String stationId) async {
-    await FavoriteService.toggleFavorite(stationId);
-    if (_favoriteStationIds.contains(stationId)) {
+    final wasFavorite = _favoriteStationIds.contains(stationId);
+    if (wasFavorite) {
       _favoriteStationIds.remove(stationId);
     } else {
       _favoriteStationIds.add(stationId);
     }
     notifyListeners();
+    try {
+      if (wasFavorite) {
+        await FavoriteService.removeFavorite(stationId);
+      } else {
+        await FavoriteService.addFavorite(stationId);
+      }
+    } catch (e) {
+      // Roll back on failure
+      if (wasFavorite) {
+        _favoriteStationIds.add(stationId);
+      } else {
+        _favoriteStationIds.remove(stationId);
+      }
+      notifyListeners();
+      rethrow;
+    }
   }
 
   bool isFavorite(String stationId) => _favoriteStationIds.contains(stationId);
@@ -170,6 +188,37 @@ class StationProvider extends ChangeNotifier {
     return result.toList();
   }
 
+  String? get bestMapStationId => _bestMapStationId;
+
+  void _recomputeBestMapStation() {
+    String? bestId;
+    double bestPrice = double.infinity;
+    for (final station in _mapStations) {
+      final p = station.prices[_selectedFuelType];
+      if (p != null && p.price < bestPrice) {
+        bestPrice = p.price;
+        bestId = station.id;
+      }
+    }
+    _bestMapStationId = bestId;
+  }
+
+  /// Stations from the last bbox fetch, filtered by brand/favorites.
+  /// Used exclusively by the map screen.
+  List<Station> get mapStations {
+    Iterable<Station> result = _mapStations;
+
+    if (_selectedBrands.isNotEmpty) {
+      result = result.where((s) => _selectedBrands.contains(s.brand));
+    }
+
+    if (_showFavoritesOnly) {
+      result = result.where((s) => _favoriteStationIds.contains(s.id));
+    }
+
+    return result.toList();
+  }
+
   void toggleBrand(String brand) {
     _selectedBrands = Set.of(_selectedBrands);
     if (_selectedBrands.contains(brand)) {
@@ -185,14 +234,14 @@ class StationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Load stations and prices from Firestore aggregate docs (2 reads).
+  /// Load stations and prices from the backend API.
   /// Called on app startup.
   Future<void> loadStations() async {
     _isLoading = true;
     notifyListeners();
 
     try {
-      await _fetchFromFirestore();
+      await _fetchFromBackend();
     } catch (e) {
       debugPrint('Failed to load stations: $e');
     } finally {
@@ -201,28 +250,13 @@ class StationProvider extends ChangeNotifier {
     }
   }
 
-  /// Re-read aggregates from Firestore, bypassing cache (2 reads).
-  Future<void> refreshFromFirestore() async {
-    _isLoading = true;
-    notifyListeners();
-
-    try {
-      await _fetchFromFirestore();
-    } catch (e) {
-      debugPrint('Failed to refresh from Firestore: $e');
-    } finally {
-      _isLoading = false;
-      notifyListeners();
-    }
-  }
-
-  /// Refresh by re-reading aggregates from Firestore, bypassing cache (2 reads).
+  /// Re-fetch stations and prices from the backend.
   Future<void> refreshStations() async {
     _isLoading = true;
     notifyListeners();
 
     try {
-      await _fetchFromFirestore();
+      await _fetchFromBackend();
     } catch (e) {
       debugPrint('Failed to refresh stations: $e');
       rethrow;
@@ -232,16 +266,40 @@ class StationProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> _fetchFromFirestore() async {
-    final stations = await FirestoreService.getStations();
-    final prices = await FirestoreService.getPrices();
+  Future<void> loadStationsByBbox({
+    required double minLat,
+    required double minLng,
+    required double maxLat,
+    required double maxLng,
+  }) async {
+    try {
+      final client = BackendApiClient();
+      _mapStations = await client.getStationsByBbox(
+        minLat: minLat,
+        minLng: minLng,
+        maxLat: maxLat,
+        maxLng: maxLng,
+      );
+      _recomputeBestMapStation();
+      notifyListeners();
+    } catch (e) {
+      debugPrint('Failed to load stations by bbox: $e');
+    }
+  }
 
-    _stations = stations;
-    _prices = prices;
+  Future<void> _fetchFromBackend() async {
+    final client = BackendApiClient();
+    // Use user location if available; fall back to Norway center + full-country radius.
+    final lat = _userLat ?? 65.0;
+    final lng = _userLng ?? 17.0;
+    final distance = _userLat != null ? 200000.0 : 2500000.0;
+    _stations = await client.getStations(
+      lat: lat,
+      lng: lng,
+      distance: distance,
+    );
 
-    // Update local cache
-    await CacheService.cacheStations(stations);
-    await CacheService.cachePrices(prices);
+    await CacheService.cacheStations(_stations);
 
     // Load remote brand logos and update BrandLogo cache
     try {
@@ -254,28 +312,13 @@ class StationProvider extends ChangeNotifier {
 
   void setFuelType(FuelType type) {
     _selectedFuelType = type;
+    _recomputeBestMapStation();
     notifyListeners();
   }
 
   void setSortMode(SortMode mode) {
     _sortMode = mode;
     notifyListeners();
-  }
-
-  /// Get the current price for a station and the selected fuel type.
-  CurrentPrice? getPriceForStation(String stationId) {
-    try {
-      return _prices.firstWhere(
-        (p) => p.stationId == stationId && p.fuelType == _selectedFuelType,
-      );
-    } catch (_) {
-      return null;
-    }
-  }
-
-  /// Get all prices for a specific station.
-  List<CurrentPrice> getPricesForStation(String stationId) {
-    return _prices.where((p) => p.stationId == stationId).toList();
   }
 
   /// Stations filtered by brand and sorted by the current sort mode.
@@ -286,9 +329,8 @@ class StationProvider extends ChangeNotifier {
     switch (_sortMode) {
       case SortMode.cheapest:
         all.sort((a, b) {
-          final pa = getPriceForStation(a.id);
-          final pb = getPriceForStation(b.id);
-          // Stations with prices come first
+          final pa = a.prices[_selectedFuelType];
+          final pb = b.prices[_selectedFuelType];
           if (pa == null && pb == null) return a.name.compareTo(b.name);
           if (pa == null) return 1;
           if (pb == null) return -1;
@@ -316,8 +358,8 @@ class StationProvider extends ChangeNotifier {
         }
       case SortMode.latest:
         all.sort((a, b) {
-          final pa = getPriceForStation(a.id);
-          final pb = getPriceForStation(b.id);
+          final pa = a.prices[_selectedFuelType];
+          final pb = b.prices[_selectedFuelType];
           if (pa == null && pb == null) return a.name.compareTo(b.name);
           if (pa == null) return 1;
           if (pb == null) return -1;

--- a/lib/screens/contribute/contribute_screen.dart
+++ b/lib/screens/contribute/contribute_screen.dart
@@ -515,7 +515,8 @@ class _PriceEntryStepState extends State<_PriceEntryStep> {
   Widget build(BuildContext context) {
     final activeColor = AppColors.primaryContainer(context);
     final stationProvider = context.watch<StationProvider>();
-    final currentPrice = stationProvider.getPriceForStation(widget.station.id);
+    final currentPrice =
+        widget.station.prices[stationProvider.selectedFuelType];
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/screens/map/map_screen.dart
+++ b/lib/screens/map/map_screen.dart
@@ -16,6 +16,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -59,6 +60,7 @@ class _MapScreenState extends State<MapScreen> {
   String _searchQuery = '';
   LatLngBounds? _visibleBounds;
   bool? _previousAllowMapRotation;
+  Timer? _bboxDebounce;
 
   @override
   void initState() {
@@ -76,6 +78,7 @@ class _MapScreenState extends State<MapScreen> {
 
   @override
   void dispose() {
+    _bboxDebounce?.cancel();
     _searchController.dispose();
     _searchFocus.dispose();
     super.dispose();
@@ -111,28 +114,18 @@ class _MapScreenState extends State<MapScreen> {
   void _onMapEvent(MapCamera camera, bool hasGesture) {
     final bounds = camera.visibleBounds;
     if (_visibleBounds != bounds) {
-      setState(() => _visibleBounds = bounds);
+      _visibleBounds = bounds;
+      _bboxDebounce?.cancel();
+      _bboxDebounce = Timer(const Duration(milliseconds: 600), () {
+        if (!mounted) return;
+        context.read<StationProvider>().loadStationsByBbox(
+          minLat: bounds.south,
+          minLng: bounds.west,
+          maxLat: bounds.north,
+          maxLng: bounds.east,
+        );
+      });
     }
-  }
-
-  List<Station> _visibleStations(List<Station> stations) {
-    final bounds = _visibleBounds;
-    if (bounds == null) return stations;
-
-    // Add padding so stations at the edge don't pop in/out abruptly
-    final latPad = (bounds.north - bounds.south) * 0.2;
-    final lngPad = (bounds.east - bounds.west) * 0.2;
-    final south = bounds.south - latPad;
-    final north = bounds.north + latPad;
-    final west = bounds.west - lngPad;
-    final east = bounds.east + lngPad;
-
-    return stations.where((s) {
-      return s.latitude >= south &&
-          s.latitude <= north &&
-          s.longitude >= west &&
-          s.longitude <= east;
-    }).toList();
   }
 
   List<Station> _searchResults(List<Station> stations) {
@@ -195,20 +188,10 @@ class _MapScreenState extends State<MapScreen> {
       }
     }
 
-    final allBrandFiltered = stationProvider.brandFilteredStations;
-    final filtered = _visibleStations(allBrandFiltered);
+    final filtered = stationProvider.mapStations;
     final results = _searchResults(stationProvider.stations);
 
-    // Find best (cheapest) station for the selected fuel type
-    String? bestStationId;
-    double bestPrice = double.infinity;
-    for (final station in filtered) {
-      final p = stationProvider.getPriceForStation(station.id);
-      if (p != null && p.price < bestPrice) {
-        bestPrice = p.price;
-        bestStationId = station.id;
-      }
-    }
+    final bestStationId = stationProvider.bestMapStationId;
 
     final tileUrl = isDark
         ? 'https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png'
@@ -236,9 +219,14 @@ class _MapScreenState extends State<MapScreen> {
                       : InteractiveFlag.all & ~InteractiveFlag.rotate,
                 ),
                 onMapReady: () {
-                  setState(() {
-                    _visibleBounds = _mapController.camera.visibleBounds;
-                  });
+                  final bounds = _mapController.camera.visibleBounds;
+                  _visibleBounds = bounds;
+                  context.read<StationProvider>().loadStationsByBbox(
+                    minLat: bounds.south,
+                    minLng: bounds.west,
+                    maxLat: bounds.north,
+                    maxLng: bounds.east,
+                  );
                   // Nudge tiles to load — flutter_map may not render
                   // tiles when built behind a dialog or IndexedStack.
                   Future.delayed(const Duration(milliseconds: 200), () {
@@ -303,15 +291,15 @@ class _MapScreenState extends State<MapScreen> {
                     maxZoom: 15,
                     showPolygon: false,
                     markers: filtered.map((station) {
-                      final price = stationProvider.getPriceForStation(
-                        station.id,
-                      );
+                      final price =
+                          station.prices[stationProvider.selectedFuelType];
                       final isBest = station.id == bestStationId;
                       return Marker(
                         point: LatLng(station.latitude, station.longitude),
                         width: 72,
                         height: price != null ? 72 : 48,
                         child: StationMarker(
+                          key: ValueKey(station.id),
                           station: station,
                           price: price,
                           isBestPrice: isBest,

--- a/lib/screens/map/widgets/station_bottom_sheet.dart
+++ b/lib/screens/map/widgets/station_bottom_sheet.dart
@@ -243,7 +243,7 @@ class _StationTileState extends State<_StationTile> {
   Widget build(BuildContext context) {
     final stationProvider = context.read<StationProvider>();
     final locationProvider = context.read<LocationProvider>();
-    final price = stationProvider.getPriceForStation(widget.station.id);
+    final price = widget.station.prices[stationProvider.selectedFuelType];
 
     String? distanceStr;
     if (locationProvider.hasLocation) {

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -29,7 +29,6 @@ import '../../config/app_text_styles.dart';
 import '../../config/constants.dart';
 import '../../config/routes.dart';
 import '../../l10n/l10n_helper.dart';
-import '../../providers/station_provider.dart';
 import '../../providers/user_provider.dart';
 import '../../services/firestore_service.dart';
 import '../../widgets/onboarding_dialog.dart';
@@ -42,7 +41,6 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  bool _isRefreshing = false;
   bool _isResendingEmail = false;
   int _stationSubmissionCount = 0;
   @override
@@ -68,32 +66,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
-  Future<void> _refreshStations() async {
-    setState(() => _isRefreshing = true);
-
-    final stationProvider = context.read<StationProvider>();
-    final userProvider = context.read<UserProvider>();
-    try {
-      await Future.wait([
-        stationProvider.refreshStations(),
-        userProvider.reloadUser(),
-      ]);
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(context.l10n.stationsRefreshed)));
-      }
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(context.l10n.refreshFailed)));
-      }
-    } finally {
-      if (mounted) setState(() => _isRefreshing = false);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final userProvider = context.watch<UserProvider>();
@@ -104,160 +76,194 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     return Scaffold(
       backgroundColor: AppColors.background(context),
-      body: RefreshIndicator(
-        onRefresh: _refreshStations,
-        child: CustomScrollView(
-          slivers: [
-            SliverAppBar(
-              backgroundColor: AppColors.background(context),
-              surfaceTintColor: Colors.transparent,
-              pinned: true,
-              expandedHeight: 100,
-              flexibleSpace: FlexibleSpaceBar(
-                titlePadding: const EdgeInsets.only(left: 16, bottom: 16),
-                title: Text(
-                  context.l10n.profile,
-                  style: AppTextStyles.heading(context).copyWith(fontSize: 28),
-                ),
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar(
+            backgroundColor: AppColors.background(context),
+            surfaceTintColor: Colors.transparent,
+            pinned: true,
+            expandedHeight: 100,
+            flexibleSpace: FlexibleSpaceBar(
+              titlePadding: const EdgeInsets.only(left: 16, bottom: 16),
+              title: Text(
+                context.l10n.profile,
+                style: AppTextStyles.heading(context).copyWith(fontSize: 28),
               ),
             ),
-            SliverPadding(
-              padding: EdgeInsets.only(
-                left: 16,
-                right: 16,
-                bottom: MediaQuery.of(context).padding.bottom + 100,
-              ),
-              sliver: SliverList(
-                delegate: SliverChildListDelegate([
-                  // ── Profile Hero ──
-                  _ProfileHero(
-                    user: user,
-                    isAuthenticated: isAuth,
-                    userProvider: userProvider,
-                  ),
+          ),
+          SliverPadding(
+            padding: EdgeInsets.only(
+              left: 16,
+              right: 16,
+              bottom: MediaQuery.of(context).padding.bottom + 100,
+            ),
+            sliver: SliverList(
+              delegate: SliverChildListDelegate([
+                // ── Profile Hero ──
+                _ProfileHero(
+                  user: user,
+                  isAuthenticated: isAuth,
+                  userProvider: userProvider,
+                ),
 
-                  // ── Email Verification Banner ──
-                  if (isAuth &&
-                      userProvider.hasEmailProvider &&
-                      !userProvider.isEmailVerified) ...[
-                    const SizedBox(height: 16),
-                    Container(
-                      padding: const EdgeInsets.all(14),
-                      decoration: BoxDecoration(
-                        color: isDark
-                            ? Colors.orange.withValues(alpha: 0.15)
-                            : Colors.orange.withValues(alpha: 0.08),
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(
-                          color: Colors.orange.withValues(alpha: 0.3),
-                          width: 0.5,
-                        ),
-                      ),
-                      child: Row(
-                        children: [
-                          Icon(
-                            Icons.mark_email_unread_outlined,
-                            color: Colors.orange,
-                            size: 22,
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  context.l10n.emailNotVerified,
-                                  style: AppTextStyles.bodyMedium(context),
-                                ),
-                                const SizedBox(height: 2),
-                                Text(
-                                  context.l10n.emailNotVerifiedSubtitle,
-                                  style: AppTextStyles.label(context),
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          TextButton(
-                            onPressed: _isResendingEmail
-                                ? null
-                                : () async {
-                                    setState(() => _isResendingEmail = true);
-                                    try {
-                                      await userProvider
-                                          .sendVerificationEmail();
-                                      if (!context.mounted) return;
-                                      ScaffoldMessenger.of(
-                                        context,
-                                      ).showSnackBar(
-                                        SnackBar(
-                                          content: Text(
-                                            context.l10n.verificationEmailSent,
-                                          ),
-                                        ),
-                                      );
-                                    } catch (e) {
-                                      if (!context.mounted) return;
-                                      ScaffoldMessenger.of(
-                                        context,
-                                      ).showSnackBar(
-                                        SnackBar(content: Text(e.toString())),
-                                      );
-                                    } finally {
-                                      if (mounted) {
-                                        setState(
-                                          () => _isResendingEmail = false,
-                                        );
-                                      }
-                                    }
-                                  },
-                            child: Text(context.l10n.resendVerificationEmail),
-                          ),
-                        ],
+                // ── Email Verification Banner ──
+                if (isAuth &&
+                    userProvider.hasEmailProvider &&
+                    !userProvider.isEmailVerified) ...[
+                  const SizedBox(height: 16),
+                  Container(
+                    padding: const EdgeInsets.all(14),
+                    decoration: BoxDecoration(
+                      color: isDark
+                          ? Colors.orange.withValues(alpha: 0.15)
+                          : Colors.orange.withValues(alpha: 0.08),
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: Colors.orange.withValues(alpha: 0.3),
+                        width: 0.5,
                       ),
                     ),
-                  ],
-
-                  const SizedBox(height: 20),
-
-                  // ── Contributions Card ──
-                  if (isAuth) ...[
-                    Container(
-                      padding: const EdgeInsets.all(18),
-                      decoration: BoxDecoration(
-                        color: AppColors.surface(context),
-                        borderRadius: BorderRadius.circular(16),
-                        border: Border.all(
-                          color: AppColors.border(context),
-                          width: 0.5,
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.mark_email_unread_outlined,
+                          color: Colors.orange,
+                          size: 22,
                         ),
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              Icon(
-                                Icons.bar_chart_rounded,
-                                size: 20,
-                                color: activeColor,
-                              ),
-                              const SizedBox(width: 8),
                               Text(
-                                context.l10n.totalContributions,
+                                context.l10n.emailNotVerified,
                                 style: AppTextStyles.bodyMedium(context),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                context.l10n.emailNotVerifiedSubtitle,
+                                style: AppTextStyles.label(context),
                               ),
                             ],
                           ),
-                          const SizedBox(height: 12),
-                          Row(
-                            children: [
-                              // Price reports
-                              Expanded(
-                                child: ConstrainedBox(
-                                  constraints: const BoxConstraints(
-                                    minHeight: 80,
+                        ),
+                        const SizedBox(width: 8),
+                        TextButton(
+                          onPressed: _isResendingEmail
+                              ? null
+                              : () async {
+                                  setState(() => _isResendingEmail = true);
+                                  try {
+                                    await userProvider.sendVerificationEmail();
+                                    if (!context.mounted) return;
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content: Text(
+                                          context.l10n.verificationEmailSent,
+                                        ),
+                                      ),
+                                    );
+                                  } catch (e) {
+                                    if (!context.mounted) return;
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(content: Text(e.toString())),
+                                    );
+                                  } finally {
+                                    if (mounted) {
+                                      setState(() => _isResendingEmail = false);
+                                    }
+                                  }
+                                },
+                          child: Text(context.l10n.resendVerificationEmail),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+
+                const SizedBox(height: 20),
+
+                // ── Contributions Card ──
+                if (isAuth) ...[
+                  Container(
+                    padding: const EdgeInsets.all(18),
+                    decoration: BoxDecoration(
+                      color: AppColors.surface(context),
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                        color: AppColors.border(context),
+                        width: 0.5,
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.bar_chart_rounded,
+                              size: 20,
+                              color: activeColor,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              context.l10n.totalContributions,
+                              style: AppTextStyles.bodyMedium(context),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            // Price reports
+                            Expanded(
+                              child: ConstrainedBox(
+                                constraints: const BoxConstraints(
+                                  minHeight: 80,
+                                ),
+                                child: Container(
+                                  padding: const EdgeInsets.all(14),
+                                  decoration: BoxDecoration(
+                                    color: AppColors.surfaceLow(context),
+                                    borderRadius: BorderRadius.circular(10),
                                   ),
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text(
+                                        '${user.reportCount}',
+                                        style: AppTextStyles.priceLarge(
+                                          context,
+                                        ).copyWith(fontSize: 24),
+                                      ),
+                                      const SizedBox(height: 2),
+                                      Text(
+                                        context.l10n.priceReportsSubmitted,
+                                        style: AppTextStyles.meta(context),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 10),
+                            // Station submissions — clickable
+                            Expanded(
+                              child: ConstrainedBox(
+                                constraints: const BoxConstraints(
+                                  minHeight: 80,
+                                ),
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(10),
+                                  onTap: () async {
+                                    await Navigator.pushNamed(
+                                      context,
+                                      AppRoutes.myStationSubmissions,
+                                    );
+                                    _loadSubmissionCount();
+                                  },
                                   child: Container(
                                     padding: const EdgeInsets.all(14),
                                     decoration: BoxDecoration(
@@ -270,15 +276,27 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                       mainAxisAlignment:
                                           MainAxisAlignment.center,
                                       children: [
-                                        Text(
-                                          '${user.reportCount}',
-                                          style: AppTextStyles.priceLarge(
-                                            context,
-                                          ).copyWith(fontSize: 24),
+                                        Row(
+                                          children: [
+                                            Text(
+                                              '$_stationSubmissionCount',
+                                              style: AppTextStyles.priceLarge(
+                                                context,
+                                              ).copyWith(fontSize: 24),
+                                            ),
+                                            const Spacer(),
+                                            Icon(
+                                              Icons.chevron_right,
+                                              size: 18,
+                                              color: AppColors.textMuted(
+                                                context,
+                                              ),
+                                            ),
+                                          ],
                                         ),
                                         const SizedBox(height: 2),
                                         Text(
-                                          context.l10n.priceReportsSubmitted,
+                                          context.l10n.stationsSubmitted,
                                           style: AppTextStyles.meta(context),
                                         ),
                                       ],
@@ -286,386 +304,306 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                   ),
                                 ),
                               ),
-                              const SizedBox(width: 10),
-                              // Station submissions — clickable
-                              Expanded(
-                                child: ConstrainedBox(
-                                  constraints: const BoxConstraints(
-                                    minHeight: 80,
-                                  ),
-                                  child: InkWell(
-                                    borderRadius: BorderRadius.circular(10),
-                                    onTap: () async {
-                                      await Navigator.pushNamed(
-                                        context,
-                                        AppRoutes.myStationSubmissions,
-                                      );
-                                      _loadSubmissionCount();
-                                    },
-                                    child: Container(
-                                      padding: const EdgeInsets.all(14),
-                                      decoration: BoxDecoration(
-                                        color: AppColors.surfaceLow(context),
-                                        borderRadius: BorderRadius.circular(10),
-                                      ),
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.center,
-                                        children: [
-                                          Row(
-                                            children: [
-                                              Text(
-                                                '$_stationSubmissionCount',
-                                                style: AppTextStyles.priceLarge(
-                                                  context,
-                                                ).copyWith(fontSize: 24),
-                                              ),
-                                              const Spacer(),
-                                              Icon(
-                                                Icons.chevron_right,
-                                                size: 18,
-                                                color: AppColors.textMuted(
-                                                  context,
-                                                ),
-                                              ),
-                                            ],
-                                          ),
-                                          const SizedBox(height: 2),
-                                          Text(
-                                            context.l10n.stationsSubmitted,
-                                            style: AppTextStyles.meta(context),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 12),
-                          // Trust score bar
-                          Row(
-                            children: [
-                              Text(
-                                context.l10n.trustScore,
-                                style: AppTextStyles.label(context),
-                              ),
-                              const Spacer(),
-                              Text(
-                                '${(user.trustScore * 100).toStringAsFixed(0)}%',
-                                style: AppTextStyles.labelBold(
-                                  context,
-                                ).copyWith(color: activeColor),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 6),
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(4),
-                            child: LinearProgressIndicator(
-                              value: user.trustScore,
-                              minHeight: 6,
-                              backgroundColor: AppColors.surfaceLow(context),
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                activeColor,
-                              ),
                             ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 24),
-                  ],
-
-                  // ── Sign In / Create Account ──
-                  if (!isAuth) ...[
-                    _ActionCard(
-                      icon: Icons.person_add_rounded,
-                      iconColor: activeColor,
-                      title: context.l10n.createAccount,
-                      subtitle: context.l10n.signUpSubtitle,
-                      onTap: () => Navigator.pushNamed(context, AppRoutes.auth),
-                      isPrimary: true,
-                    ),
-                    const SizedBox(height: 24),
-                  ],
-
-                  // ── Admin Panel ──
-                  if (userProvider.isAdmin) ...[
-                    Text(
-                      context.l10n.adminSection,
-                      style: AppTextStyles.sectionHeader(context),
-                    ),
-                    const SizedBox(height: 12),
-                    _SettingsCard(
-                      children: [
-                        _SettingsTile(
-                          icon: Icons.admin_panel_settings_outlined,
-                          iconColor: Colors.orange,
-                          title: context.l10n.adminPanel,
-                          subtitle: context.l10n.adminPanelSubtitle,
-                          onTap: () => Navigator.pushNamed(
-                            context,
-                            AppRoutes.adminSubmissions,
-                          ),
+                          ],
                         ),
-                        const _CardDivider(),
-                        _SettingsTile(
-                          icon: Icons.edit_note_outlined,
-                          iconColor: Colors.orange,
-                          title: context.l10n.modifyRequests,
-                          subtitle: context.l10n.modifyRequestsSubtitle,
-                          onTap: () => Navigator.pushNamed(
-                            context,
-                            AppRoutes.adminModifyRequests,
+                        const SizedBox(height: 12),
+                        // Trust score bar
+                        Row(
+                          children: [
+                            Text(
+                              context.l10n.trustScore,
+                              style: AppTextStyles.label(context),
+                            ),
+                            const Spacer(),
+                            Text(
+                              '${(user.trustScore * 100).toStringAsFixed(0)}%',
+                              style: AppTextStyles.labelBold(
+                                context,
+                              ).copyWith(color: activeColor),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 6),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: user.trustScore,
+                            minHeight: 6,
+                            backgroundColor: AppColors.surfaceLow(context),
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              activeColor,
+                            ),
                           ),
                         ),
                       ],
                     ),
-                    const SizedBox(height: 24),
+                  ),
+                  const SizedBox(height: 24),
+                ],
+
+                // ── Sign In / Create Account ──
+                if (!isAuth) ...[
+                  _ActionCard(
+                    icon: Icons.person_add_rounded,
+                    iconColor: activeColor,
+                    title: context.l10n.createAccount,
+                    subtitle: context.l10n.signUpSubtitle,
+                    onTap: () => Navigator.pushNamed(context, AppRoutes.auth),
+                    isPrimary: true,
+                  ),
+                  const SizedBox(height: 24),
+                ],
+
+                // ── Admin Panel ──
+                if (userProvider.isAdmin) ...[
+                  Text(
+                    context.l10n.adminSection,
+                    style: AppTextStyles.sectionHeader(context),
+                  ),
+                  const SizedBox(height: 12),
+                  _SettingsCard(
+                    children: [
+                      _SettingsTile(
+                        icon: Icons.admin_panel_settings_outlined,
+                        iconColor: Colors.orange,
+                        title: context.l10n.adminPanel,
+                        subtitle: context.l10n.adminPanelSubtitle,
+                        onTap: () => Navigator.pushNamed(
+                          context,
+                          AppRoutes.adminSubmissions,
+                        ),
+                      ),
+                      const _CardDivider(),
+                      _SettingsTile(
+                        icon: Icons.edit_note_outlined,
+                        iconColor: Colors.orange,
+                        title: context.l10n.modifyRequests,
+                        subtitle: context.l10n.modifyRequestsSubtitle,
+                        onTap: () => Navigator.pushNamed(
+                          context,
+                          AppRoutes.adminModifyRequests,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                ],
+
+                // ── Map Preferences ──
+                Text(
+                  context.l10n.mapPreferences,
+                  style: AppTextStyles.sectionHeader(context),
+                ),
+                const SizedBox(height: 12),
+                _SettingsCard(
+                  children: [
+                    _ThemeModeTile(themeMode: userProvider.themeMode),
+                    const _CardDivider(),
+                    _LanguageTile(locale: userProvider.locale),
                   ],
+                ),
+                const SizedBox(height: 24),
 
-                  // ── Map Preferences ──
-                  Text(
-                    context.l10n.mapPreferences,
-                    style: AppTextStyles.sectionHeader(context),
-                  ),
-                  const SizedBox(height: 12),
-                  _SettingsCard(
-                    children: [
-                      _ThemeModeTile(themeMode: userProvider.themeMode),
-                      const _CardDivider(),
-                      _LanguageTile(locale: userProvider.locale),
-                      const _CardDivider(),
-                      _SettingsTile(
-                        icon: Icons.my_location_outlined,
-                        iconColor: isDark
-                            ? const Color(0xFF6fddaa)
-                            : const Color(0xFF10B981),
-                        title: context.l10n.refreshStations,
-                        subtitle: context.l10n.updateNearbyStations,
-                        trailing: _isRefreshing
-                            ? SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: activeColor,
-                                ),
-                              )
-                            : null,
-                        onTap: _isRefreshing ? null : _refreshStations,
-                        showLoadingOnTap: false,
+                // ── Support ──
+                Text(
+                  context.l10n.support,
+                  style: AppTextStyles.sectionHeader(context),
+                ),
+                const SizedBox(height: 12),
+                _SettingsCard(
+                  children: [
+                    _SettingsTile(
+                      icon: Icons.lightbulb_outline,
+                      iconColor: isDark
+                          ? const Color(0xFFffd166)
+                          : const Color(0xFFF59E0B),
+                      title: context.l10n.tips,
+                      subtitle: context.l10n.tipsSubtitle,
+                      trailing: Icon(
+                        Icons.arrow_forward_ios,
+                        size: 14,
+                        color: AppColors.textMuted(context),
                       ),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
-
-                  // ── Support ──
-                  Text(
-                    context.l10n.support,
-                    style: AppTextStyles.sectionHeader(context),
-                  ),
-                  const SizedBox(height: 12),
-                  _SettingsCard(
-                    children: [
-                      _SettingsTile(
-                        icon: Icons.lightbulb_outline,
-                        iconColor: isDark
-                            ? const Color(0xFFffd166)
-                            : const Color(0xFFF59E0B),
-                        title: context.l10n.tips,
-                        subtitle: context.l10n.tipsSubtitle,
-                        trailing: Icon(
-                          Icons.arrow_forward_ios,
-                          size: 14,
-                          color: AppColors.textMuted(context),
-                        ),
-                        onTap: () => showOnboarding(context),
-                      ),
-                      const _CardDivider(),
-                      _SettingsTile(
-                        icon: Icons.bug_report_outlined,
-                        iconColor: isDark
-                            ? const Color(0xFFffd166)
-                            : const Color(0xFFF59E0B),
-                        title: context.l10n.reportABug,
-                        subtitle: context.l10n.foundIssue,
-                        trailing: Icon(
-                          Icons.arrow_forward_ios,
-                          size: 14,
-                          color: AppColors.textMuted(context),
-                        ),
-                        onTap: () =>
-                            Navigator.pushNamed(context, AppRoutes.bugReport),
-                      ),
-                      const _CardDivider(),
-                      _SettingsTile(
-                        icon: Icons.info_outline,
-                        iconColor: isDark
-                            ? const Color(0xFFa4e6ff)
-                            : const Color(0xFF6366F1),
-                        title: context.l10n.about,
-                        subtitle: AppConstants.appName,
-                        trailing: Icon(
-                          Icons.arrow_forward_ios,
-                          size: 14,
-                          color: AppColors.textMuted(context),
-                        ),
-                        onTap: () async {
-                          final info = await PackageInfo.fromPlatform();
-                          if (!context.mounted) return;
-                          showAboutDialog(
-                            context: context,
-                            applicationName: AppConstants.appName,
-                            applicationVersion:
-                                '${info.version}+${info.buildNumber}',
-                            children: [
-                              Text(context.l10n.aboutDescription),
-                              const SizedBox(height: 16),
-                              OutlinedButton.icon(
-                                icon: ClipOval(
-                                  child: Image.asset(
-                                    'assets/logos/github.png',
-                                    width: 18,
-                                    height: 18,
-                                  ),
-                                ),
-                                label: Text(context.l10n.viewOnGithub),
-                                onPressed: () {
-                                  launchUrl(
-                                    Uri.parse(
-                                      'https://github.com/Drivstoffpriser/Drivstoffpriser-App',
-                                    ),
-                                    mode: LaunchMode.externalApplication,
-                                  );
-                                },
-                              ),
-                            ],
-                          );
-                        },
-                        showLoadingOnTap: false,
-                      ),
-                      const _CardDivider(),
-                      _SettingsTile(
-                        icon: Icons.privacy_tip_outlined,
-                        iconColor: isDark
-                            ? const Color(0xFF6fddaa)
-                            : const Color(0xFF10B981),
-                        title: context.l10n.privacyPolicy,
-                        subtitle: context.l10n.privacyPolicySubtitle,
-                        trailing: Icon(
-                          Icons.arrow_forward_ios,
-                          size: 14,
-                          color: AppColors.textMuted(context),
-                        ),
-                        onTap: () {
-                          launchUrl(
-                            Uri.parse(
-                              'https://drivstoffpriser.github.io/Drivstoffpriser-App/privacy-policy.html',
-                            ),
-                            mode: LaunchMode.externalApplication,
-                          );
-                        },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
-
-                  // ── Account Management ──
-                  if (isAuth) ...[
-                    Text(
-                      context.l10n.account,
-                      style: AppTextStyles.sectionHeader(context),
+                      onTap: () => showOnboarding(context),
                     ),
-                    const SizedBox(height: 12),
-                    _SettingsCard(
-                      children: [
-                        _SettingsTile(
-                          icon: Icons.delete_forever_rounded,
-                          iconColor: isDark
-                              ? AppColors.darkError
-                              : const Color(0xFFDC2626),
-                          title: context.l10n.deleteAccount,
-                          subtitle: context.l10n.deleteAccountSubtitle,
-                          onTap: () async {
-                            final confirmed = await showDialog<bool>(
-                              context: context,
-                              builder: (ctx) => AlertDialog(
-                                title: Text(ctx.l10n.deleteAccountConfirmTitle),
-                                content: Text(
-                                  ctx.l10n.deleteAccountConfirmBody,
+                    const _CardDivider(),
+                    _SettingsTile(
+                      icon: Icons.bug_report_outlined,
+                      iconColor: isDark
+                          ? const Color(0xFFffd166)
+                          : const Color(0xFFF59E0B),
+                      title: context.l10n.reportABug,
+                      subtitle: context.l10n.foundIssue,
+                      trailing: Icon(
+                        Icons.arrow_forward_ios,
+                        size: 14,
+                        color: AppColors.textMuted(context),
+                      ),
+                      onTap: () =>
+                          Navigator.pushNamed(context, AppRoutes.bugReport),
+                    ),
+                    const _CardDivider(),
+                    _SettingsTile(
+                      icon: Icons.info_outline,
+                      iconColor: isDark
+                          ? const Color(0xFFa4e6ff)
+                          : const Color(0xFF6366F1),
+                      title: context.l10n.about,
+                      subtitle: AppConstants.appName,
+                      trailing: Icon(
+                        Icons.arrow_forward_ios,
+                        size: 14,
+                        color: AppColors.textMuted(context),
+                      ),
+                      onTap: () async {
+                        final info = await PackageInfo.fromPlatform();
+                        if (!context.mounted) return;
+                        showAboutDialog(
+                          context: context,
+                          applicationName: AppConstants.appName,
+                          applicationVersion:
+                              '${info.version}+${info.buildNumber}',
+                          children: [
+                            Text(context.l10n.aboutDescription),
+                            const SizedBox(height: 16),
+                            OutlinedButton.icon(
+                              icon: ClipOval(
+                                child: Image.asset(
+                                  'assets/logos/github.png',
+                                  width: 18,
+                                  height: 18,
                                 ),
-                                actions: [
-                                  TextButton(
-                                    onPressed: () => Navigator.pop(ctx, false),
-                                    child: Text(ctx.l10n.cancel),
+                              ),
+                              label: Text(context.l10n.viewOnGithub),
+                              onPressed: () {
+                                launchUrl(
+                                  Uri.parse(
+                                    'https://github.com/Drivstoffpriser/Drivstoffpriser-App',
                                   ),
-                                  TextButton(
-                                    style: TextButton.styleFrom(
-                                      foregroundColor: const Color(0xFFDC2626),
-                                    ),
-                                    onPressed: () => Navigator.pop(ctx, true),
-                                    child: Text(
-                                      ctx.l10n.deleteAccountConfirmButton,
-                                    ),
+                                  mode: LaunchMode.externalApplication,
+                                );
+                              },
+                            ),
+                          ],
+                        );
+                      },
+                      showLoadingOnTap: false,
+                    ),
+                    const _CardDivider(),
+                    _SettingsTile(
+                      icon: Icons.privacy_tip_outlined,
+                      iconColor: isDark
+                          ? const Color(0xFF6fddaa)
+                          : const Color(0xFF10B981),
+                      title: context.l10n.privacyPolicy,
+                      subtitle: context.l10n.privacyPolicySubtitle,
+                      trailing: Icon(
+                        Icons.arrow_forward_ios,
+                        size: 14,
+                        color: AppColors.textMuted(context),
+                      ),
+                      onTap: () {
+                        launchUrl(
+                          Uri.parse(
+                            'https://drivstoffpriser.github.io/Drivstoffpriser-App/privacy-policy.html',
+                          ),
+                          mode: LaunchMode.externalApplication,
+                        );
+                      },
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+
+                // ── Account Management ──
+                if (isAuth) ...[
+                  Text(
+                    context.l10n.account,
+                    style: AppTextStyles.sectionHeader(context),
+                  ),
+                  const SizedBox(height: 12),
+                  _SettingsCard(
+                    children: [
+                      _SettingsTile(
+                        icon: Icons.delete_forever_rounded,
+                        iconColor: isDark
+                            ? AppColors.darkError
+                            : const Color(0xFFDC2626),
+                        title: context.l10n.deleteAccount,
+                        subtitle: context.l10n.deleteAccountSubtitle,
+                        onTap: () async {
+                          final confirmed = await showDialog<bool>(
+                            context: context,
+                            builder: (ctx) => AlertDialog(
+                              title: Text(ctx.l10n.deleteAccountConfirmTitle),
+                              content: Text(ctx.l10n.deleteAccountConfirmBody),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.pop(ctx, false),
+                                  child: Text(ctx.l10n.cancel),
+                                ),
+                                TextButton(
+                                  style: TextButton.styleFrom(
+                                    foregroundColor: const Color(0xFFDC2626),
                                   ),
-                                ],
+                                  onPressed: () => Navigator.pop(ctx, true),
+                                  child: Text(
+                                    ctx.l10n.deleteAccountConfirmButton,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                          if (confirmed != true || !context.mounted) return;
+                          try {
+                            await userProvider.deleteAccount();
+                            if (!context.mounted) return;
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text(context.l10n.accountDeleted),
                               ),
                             );
-                            if (confirmed != true || !context.mounted) return;
-                            try {
-                              await userProvider.deleteAccount();
-                              if (!context.mounted) return;
+                          } on FirebaseAuthException catch (e) {
+                            if (!context.mounted) return;
+                            if (e.code == 'requires-recent-login') {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
-                                  content: Text(context.l10n.accountDeleted),
+                                  content: Text(
+                                    context.l10n.deleteAccountReauth,
+                                  ),
                                 ),
                               );
-                            } on FirebaseAuthException catch (e) {
-                              if (!context.mounted) return;
-                              if (e.code == 'requires-recent-login') {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text(
-                                      context.l10n.deleteAccountReauth,
-                                    ),
-                                  ),
-                                );
-                              } else {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(content: Text(e.message ?? e.code)),
-                                );
-                              }
+                            } else {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(e.message ?? e.code)),
+                              );
                             }
-                          },
-                          showLoadingOnTap: false,
-                        ),
-                        const _CardDivider(),
-                        _SettingsTile(
-                          icon: Icons.logout_rounded,
-                          iconColor: isDark
-                              ? AppColors.darkError
-                              : const Color(0xFFDC2626),
-                          title: context.l10n.signOut,
-                          subtitle: context.l10n.signOutSubtitle,
-                          onTap: () async {
-                            await userProvider.signOut();
-                          },
-                        ),
-                      ],
-                    ),
-                  ],
+                          }
+                        },
+                        showLoadingOnTap: false,
+                      ),
+                      const _CardDivider(),
+                      _SettingsTile(
+                        icon: Icons.logout_rounded,
+                        iconColor: isDark
+                            ? AppColors.darkError
+                            : const Color(0xFFDC2626),
+                        title: context.l10n.signOut,
+                        subtitle: context.l10n.signOutSubtitle,
+                        onTap: () async {
+                          await userProvider.signOut();
+                        },
+                      ),
+                    ],
+                  ),
+                ],
 
-                  const SizedBox(height: 32),
-                ]),
-              ),
+                const SizedBox(height: 32),
+              ]),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/station_detail/station_detail_screen.dart
+++ b/lib/screens/station_detail/station_detail_screen.dart
@@ -20,7 +20,6 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:timeago/timeago.dart' as timeago;
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../config/app_colors.dart';
@@ -37,6 +36,15 @@ import '../../widgets/loading_indicator.dart';
 import 'edit_station_screen.dart';
 import 'widgets/price_card.dart';
 import 'widgets/price_history_chart.dart';
+import '../submit_price/submit_price_screen.dart';
+
+String _formatAge(BuildContext context, Duration age) {
+  final minutes = age.inMinutes;
+  final hours = age.inHours;
+  if (minutes < 60) return context.l10n.ageMinutes(minutes);
+  if (hours <= 23) return context.l10n.ageHours(hours);
+  return context.l10n.ageOver1Day;
+}
 
 class StationDetailScreen extends StatefulWidget {
   final Station station;
@@ -53,7 +61,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = context.read<PriceProvider>();
-      provider.loadReports(widget.station.id);
+      provider.clear();
       provider.loadHistory(widget.station.id);
     });
   }
@@ -102,7 +110,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
     if (confirmed != true || !mounted) return;
     await FirestoreService.deleteStation(widget.station.id);
     if (mounted) {
-      await stationProvider.refreshFromFirestore();
+      await stationProvider.refreshStations();
       if (mounted) Navigator.pop(context);
     }
   }
@@ -112,7 +120,11 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
     final stationProvider = context.watch<StationProvider>();
     final priceProvider = context.watch<PriceProvider>();
     final userProvider = context.watch<UserProvider>();
-    final prices = stationProvider.getPricesForStation(widget.station.id);
+    final station = stationProvider.stations.firstWhere(
+      (s) => s.id == widget.station.id,
+      orElse: () => widget.station,
+    );
+    final prices = station.prices.values.toList();
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final activeColor = AppColors.primaryContainer(context);
 
@@ -258,39 +270,96 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
 
                 const SizedBox(height: 28),
 
-                // ── Price History Chart ──
+                // ── Report Price ──
                 Text(
-                  context.l10n.priceTrend,
+                  'Registrer pris',
                   style: AppTextStyles.sectionHeader(context),
                 ),
                 const SizedBox(height: 12),
-                if (priceProvider.isLoadingHistory)
-                  const SizedBox(height: 220, child: LoadingIndicator())
-                else if (priceProvider.history.isNotEmpty)
-                  Container(
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: AppColors.surface(context),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                        color: AppColors.border(context),
-                        width: 0.5,
+                Row(
+                  children: [
+                    Expanded(
+                      child: _GradientActionButton(
+                        icon: Icons.camera_alt_outlined,
+                        label: 'Med kamera',
+                        onPressed: () async {
+                          final priceProvider = context.read<PriceProvider>();
+                          await Navigator.pushNamed(
+                            context,
+                            AppRoutes.submitPrice,
+                            arguments: widget.station,
+                          );
+                          if (mounted) {
+                            priceProvider.loadHistory(widget.station.id);
+                          }
+                        },
                       ),
                     ),
-                    child: PriceHistoryChart(history: priceProvider.history),
-                  ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: _GradientActionButton(
+                        icon: Icons.edit_outlined,
+                        label: 'Manuelt',
+                        onPressed: () async {
+                          final priceProvider = context.read<PriceProvider>();
+                          await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) =>
+                                  SubmitPriceScreen(station: widget.station),
+                            ),
+                          );
+                          if (mounted) {
+                            priceProvider.loadHistory(widget.station.id);
+                          }
+                        },
+                      ),
+                    ),
+                  ],
+                ),
 
-                const SizedBox(height: 28),
-
-                // ── Report Price Button ──
-                _GradientActionButton(
-                  icon: Icons.add_circle_outline,
-                  label: context.l10n.reportAPrice,
-                  onPressed: () {
-                    Navigator.pushNamed(
-                      context,
-                      AppRoutes.submitPrice,
-                      arguments: widget.station,
+                // ── Price History Chart ──
+                Builder(
+                  builder: (context) {
+                    final distinctDates = priceProvider.history.values
+                        .expand(
+                          (list) => list.map(
+                            (pt) =>
+                                pt.date.toLocal().toString().substring(0, 10),
+                          ),
+                        )
+                        .toSet();
+                    if (!priceProvider.isLoadingHistory &&
+                        distinctDates.length < 2) {
+                      return const SizedBox.shrink();
+                    }
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(height: 28),
+                        Text(
+                          context.l10n.priceTrend,
+                          style: AppTextStyles.sectionHeader(context),
+                        ),
+                        const SizedBox(height: 12),
+                        if (priceProvider.isLoadingHistory)
+                          const SizedBox(height: 220, child: LoadingIndicator())
+                        else
+                          Container(
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color: AppColors.surface(context),
+                              borderRadius: BorderRadius.circular(16),
+                              border: Border.all(
+                                color: AppColors.border(context),
+                                width: 0.5,
+                              ),
+                            ),
+                            child: PriceHistoryChart(
+                              history: priceProvider.history,
+                            ),
+                          ),
+                      ],
                     );
                   },
                 ),
@@ -350,7 +419,12 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                                   style: AppTextStyles.bodyMedium(context),
                                 ),
                                 Text(
-                                  timeago.format(report.reportedAt),
+                                  _formatAge(
+                                    context,
+                                    DateTime.now().difference(
+                                      report.reportedAt,
+                                    ),
+                                  ),
                                   style: AppTextStyles.meta(context),
                                 ),
                               ],
@@ -397,7 +471,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                                   report.id,
                                 );
                                 if (mounted) {
-                                  provider.loadReports(widget.station.id);
+                                  provider.loadHistory(widget.station.id);
                                 }
                               },
                               child: Icon(
@@ -429,32 +503,26 @@ class _PriceBentoGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Display prices in a grid-like layout
-    if (prices.length == 1) {
-      return PriceCard(price: prices[0]);
+    if (prices.length <= 2) {
+      return Row(
+        children: [
+          for (int i = 0; i < prices.length; i++) ...[
+            if (i > 0) const SizedBox(width: 8),
+            Expanded(child: PriceCard(price: prices[i], compact: true)),
+          ],
+        ],
+      );
     }
 
-    final rows = <Widget>[];
-    for (int i = 0; i < prices.length; i += 2) {
-      if (i + 1 < prices.length) {
-        rows.add(
-          Row(
-            children: [
-              Expanded(child: PriceCard(price: prices[i])),
-              const SizedBox(width: 8),
-              Expanded(child: PriceCard(price: prices[i + 1])),
-            ],
-          ),
-        );
-      } else {
-        rows.add(PriceCard(price: prices[i]));
-      }
-      if (i + 2 < prices.length) {
-        rows.add(const SizedBox(height: 8));
-      }
-    }
-
-    return Column(children: rows);
+    // 3 or more: show all in one row with compact cards
+    return Row(
+      children: [
+        for (int i = 0; i < prices.length; i++) ...[
+          if (i > 0) const SizedBox(width: 6),
+          Expanded(child: PriceCard(price: prices[i], compact: true)),
+        ],
+      ],
+    );
   }
 }
 

--- a/lib/screens/station_detail/station_list_screen.dart
+++ b/lib/screens/station_detail/station_list_screen.dart
@@ -138,9 +138,8 @@ class StationListScreen extends StatelessWidget {
                       itemCount: sorted.length,
                       itemBuilder: (context, index) {
                         final station = sorted[index];
-                        final price = stationProvider.getPriceForStation(
-                          station.id,
-                        );
+                        final price =
+                            station.prices[stationProvider.selectedFuelType];
 
                         String? distanceStr;
                         if (locationProvider.hasLocation) {

--- a/lib/screens/station_detail/widgets/price_card.dart
+++ b/lib/screens/station_detail/widgets/price_card.dart
@@ -21,20 +21,20 @@ import 'package:timeago/timeago.dart' as timeago;
 
 import '../../../config/app_colors.dart';
 import '../../../config/app_text_styles.dart';
-import '../../../l10n/l10n_helper.dart';
 import '../../../models/current_price.dart';
 
 class PriceCard extends StatelessWidget {
   final CurrentPrice price;
+  final bool compact;
 
-  const PriceCard({super.key, required this.price});
+  const PriceCard({super.key, required this.price, this.compact = false});
 
   @override
   Widget build(BuildContext context) {
     final activeColor = AppColors.primaryContainer(context);
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: EdgeInsets.all(compact ? 10 : 16),
       decoration: BoxDecoration(
         color: AppColors.surface(context),
         borderRadius: BorderRadius.circular(16),
@@ -61,19 +61,24 @@ class PriceCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 10),
-          Text(
-            price.price.toStringAsFixed(2),
-            style: AppTextStyles.priceLarge(
-              context,
-            ).copyWith(fontSize: 24, color: AppColors.textPrimary(context)),
-          ),
-          Text(
-            context.l10n.krPerUnit(price.fuelType.unit),
-            style: AppTextStyles.meta(context),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text(
+                price.price.toStringAsFixed(2),
+                style: AppTextStyles.priceLarge(context).copyWith(
+                  fontSize: compact ? 20 : 24,
+                  color: AppColors.textPrimary(context),
+                ),
+              ),
+              const SizedBox(width: 4),
+              Text('kr', style: AppTextStyles.meta(context)),
+            ],
           ),
           const SizedBox(height: 8),
           Text(
-            '${context.l10n.reportsCount(price.reportCount)} · ${timeago.format(price.updatedAt)}',
+            timeago.format(price.updatedAt),
             style: AppTextStyles.meta(context),
           ),
         ],

--- a/lib/screens/station_detail/widgets/price_history_chart.dart
+++ b/lib/screens/station_detail/widgets/price_history_chart.dart
@@ -95,9 +95,13 @@ class _PriceHistoryChartState extends State<PriceHistoryChart> {
     }
 
     final dateRange = latest.difference(earliest).inDays.toDouble();
-    if (dateRange == 0) return const SizedBox.shrink();
+    // When all points share one date, pad the x-axis so the point renders.
+    final xMin = dateRange == 0 ? -1.0 : 0.0;
+    final xMax = dateRange == 0 ? 1.0 : dateRange;
 
-    final yPad = (maxPrice - minPrice) * 0.15;
+    final rawYPad = (maxPrice - minPrice) * 0.15;
+    // Guard against zero range (single price value).
+    final yPad = rawYPad == 0 ? maxPrice * 0.05 : rawYPad;
     final yMin = (minPrice - yPad).floorToDouble();
     final yMax = (maxPrice + yPad).ceilToDouble();
 
@@ -121,8 +125,8 @@ class _PriceHistoryChartState extends State<PriceHistoryChart> {
                 LineChartData(
                   minY: yMin,
                   maxY: yMax,
-                  minX: 0,
-                  maxX: dateRange,
+                  minX: xMin,
+                  maxX: xMax,
                   gridData: FlGridData(
                     horizontalInterval: ((yMax - yMin) / 4)
                         .ceilToDouble()
@@ -163,7 +167,7 @@ class _PriceHistoryChartState extends State<PriceHistoryChart> {
                         reservedSize: 44,
                         getTitlesWidget: (value, _) {
                           return Text(
-                            '${value.toStringAsFixed(1)} ${context.l10n.krSuffix}',
+                            '${value.toStringAsFixed(2)} ${context.l10n.krSuffix}',
                             style: TextStyle(fontSize: 10, color: labelColor),
                           );
                         },
@@ -196,17 +200,26 @@ class _PriceHistoryChartState extends State<PriceHistoryChart> {
                       .where((e) => _visible.contains(e.key))
                       .map((entry) {
                         final color = _fuelColor(entry.key, context);
+                        var spots = entry.value.map((pt) {
+                          final x = pt.date
+                              .difference(earliest!)
+                              .inDays
+                              .toDouble();
+                          return FlSpot(
+                            x,
+                            double.parse(pt.price.toStringAsFixed(2)),
+                          );
+                        }).toList();
+                        // fl_chart needs ≥2 spots to render anything.
+                        // Duplicate the single point with a tiny x offset.
+                        if (spots.length == 1) {
+                          spots = [
+                            FlSpot(spots[0].x - 0.01, spots[0].y),
+                            spots[0],
+                          ];
+                        }
                         return LineChartBarData(
-                          spots: entry.value.map((pt) {
-                            final x = pt.date
-                                .difference(earliest!)
-                                .inDays
-                                .toDouble();
-                            return FlSpot(
-                              x,
-                              double.parse(pt.price.toStringAsFixed(2)),
-                            );
-                          }).toList(),
+                          spots: spots,
                           isCurved: true,
                           curveSmoothness: 0.2,
                           color: color,
@@ -220,9 +233,9 @@ class _PriceHistoryChartState extends State<PriceHistoryChart> {
                                   ) ??
                                   false;
                               return FlDotCirclePainter(
-                                radius: isTouched ? 5 : 0,
+                                radius: isTouched ? 5 : 3,
                                 color: color,
-                                strokeWidth: isTouched ? 2 : 0,
+                                strokeWidth: 2,
                                 strokeColor: isDark
                                     ? AppColors.darkBackground
                                     : Colors.white,

--- a/lib/screens/submit_price/submit_price_screen.dart
+++ b/lib/screens/submit_price/submit_price_screen.dart
@@ -278,7 +278,7 @@ class _SubmitPriceScreenState extends State<SubmitPriceScreen> {
       final userProvider = context.read<UserProvider>();
       final stationProvider = context.read<StationProvider>();
       await userProvider.refreshProfile();
-      stationProvider.refreshFromFirestore();
+      stationProvider.refreshStations();
     }
 
     if (!mounted) return;

--- a/lib/services/backend_api_client.dart
+++ b/lib/services/backend_api_client.dart
@@ -22,6 +22,10 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:http/http.dart' as http;
 
 import '../config/api_config.dart';
+import '../models/fuel_type.dart';
+import '../models/price_history_point.dart';
+import '../models/price_report.dart';
+import '../models/station.dart';
 
 /// Thrown when the backend returns a non-2xx response.
 class ApiException implements Exception {
@@ -44,7 +48,16 @@ class BackendApiClient {
       headers: await _authHeaders(),
       body: jsonEncode(body),
     );
-    return _decode(response);
+    return _decodeMap(response);
+  }
+
+  Future<void> postVoid(String path, Map<String, dynamic> body) async {
+    final response = await http.post(
+      _uri(path),
+      headers: await _authHeaders(),
+      body: jsonEncode(body),
+    );
+    _checkStatus(response);
   }
 
   Future<Map<String, dynamic>> get(
@@ -55,8 +68,143 @@ class BackendApiClient {
       _uri(path, queryParams: queryParams),
       headers: await _authHeaders(),
     );
-    return _decode(response);
+    return _decodeMap(response);
   }
+
+  Future<List<dynamic>> getList(
+    String path, {
+    Map<String, String>? queryParams,
+  }) async {
+    final response = await http.get(
+      _uri(path, queryParams: queryParams),
+      headers: await _authHeaders(),
+    );
+    _checkStatus(response);
+    return jsonDecode(response.body) as List<dynamic>;
+  }
+
+  Future<void> delete(String path, Map<String, dynamic> body) async {
+    final response = await http.delete(
+      _uri(path),
+      headers: await _authHeaders(),
+      body: jsonEncode(body),
+    );
+    _checkStatus(response);
+  }
+
+  // ── Domain methods ────────────────────────────────────────────────────────
+
+  Future<List<Station>> getStations({
+    required double lat,
+    required double lng,
+    required double distance,
+  }) async {
+    final data = await get(
+      '/stations/',
+      queryParams: {
+        'lat': lat.toString(),
+        'lng': lng.toString(),
+        'distance': distance.toString(),
+      },
+    );
+    final raw = data['stations'] as List<dynamic>;
+    return [
+      for (final item in raw)
+        Station.fromBackendJson(item as Map<String, dynamic>),
+    ];
+  }
+
+  Future<List<Station>> getStationsByBbox({
+    required double minLat,
+    required double minLng,
+    required double maxLat,
+    required double maxLng,
+  }) async {
+    final data = await get(
+      '/stations/bbox',
+      queryParams: {
+        'minLat': minLat.toString(),
+        'minLng': minLng.toString(),
+        'maxLat': maxLat.toString(),
+        'maxLng': maxLng.toString(),
+      },
+    );
+    final raw = data['stations'] as List<dynamic>;
+    return [
+      for (final item in raw)
+        Station.fromBackendJson(item as Map<String, dynamic>),
+    ];
+  }
+
+  Future<void> registerPrices(
+    String stationId,
+    List<({FuelType fuelType, double price})> registrations,
+  ) async {
+    await postVoid('/stations/$stationId/prices', {
+      'registrations': [
+        for (final r in registrations)
+          {'fuelType': r.fuelType.backendString, 'price': r.price},
+      ],
+    });
+  }
+
+  Future<Set<String>> getFavorites() async {
+    final data = await get('/favorites');
+    final ids = data['stationIds'] as List<dynamic>;
+    return ids.cast<String>().toSet();
+  }
+
+  Future<void> addFavorite(String stationId) async {
+    await postVoid('/favorites', {'stationId': stationId});
+  }
+
+  Future<void> removeFavorite(String stationId) async {
+    await delete('/favorites', {'stationId': stationId});
+  }
+
+  Future<
+    ({
+      Map<FuelType, List<PriceHistoryPoint>> history,
+      List<PriceReport> recentUpdates,
+    })
+  >
+  getPriceHistory(String stationId) async {
+    final data = await get('/stations/$stationId/history');
+
+    final historyRaw = data['history'] as Map<String, dynamic>;
+    final history = <FuelType, List<PriceHistoryPoint>>{};
+    for (final entry in historyRaw.entries) {
+      final fuelType = FuelType.fromBackendString(entry.key);
+      final points = (entry.value as List<dynamic>).map((p) {
+        final map = p as Map<String, dynamic>;
+        return PriceHistoryPoint(
+          date: DateTime.parse(map['date'] as String),
+          price: _toDouble(map['averagePrice']),
+        );
+      }).toList();
+      if (points.isNotEmpty) history[fuelType] = points;
+    }
+
+    final recentRaw = data['recentUpdates'] as List<dynamic>;
+    final recentUpdates = recentRaw.map((r) {
+      final map = r as Map<String, dynamic>;
+      return PriceReport(
+        id: map['id'] as String,
+        stationId: stationId,
+        fuelType: FuelType.fromBackendString(map['fuelType'] as String),
+        price: _toDouble(map['price']),
+        userId: '',
+        reportedAt: DateTime.parse(map['registeredAt'] as String),
+      );
+    }).toList();
+
+    return (history: history, recentUpdates: recentUpdates);
+  }
+
+  static double _toDouble(dynamic v) =>
+      v is num ? v.toDouble() : double.parse(v.toString());
+
+  // ── Internal helpers ──────────────────────────────────────────────────────
 
   Uri _uri(String path, {Map<String, String>? queryParams}) {
     final base = BackendConfig.baseUrl;
@@ -76,13 +224,17 @@ class BackendApiClient {
     };
   }
 
-  Map<String, dynamic> _decode(http.Response response) {
-    if (response.statusCode >= 200 && response.statusCode < 300) {
-      return jsonDecode(response.body) as Map<String, dynamic>;
+  void _checkStatus(http.Response response) {
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ApiException(
+        response.statusCode,
+        response.reasonPhrase ?? 'Unknown error',
+      );
     }
-    throw ApiException(
-      response.statusCode,
-      response.reasonPhrase ?? 'Unknown error',
-    );
+  }
+
+  Map<String, dynamic> _decodeMap(http.Response response) {
+    _checkStatus(response);
+    return jsonDecode(response.body) as Map<String, dynamic>;
   }
 }

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -20,14 +20,11 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../models/current_price.dart';
 import '../models/station.dart';
 
 class CacheService {
   static const _stationsKey = 'cached_stations';
-  static const _pricesKey = 'cached_prices';
   static const _stationsTsKey = 'cached_stations_ts';
-  static const _pricesTsKey = 'cached_prices_ts';
 
   /// Cache TTL — data older than this is considered stale.
   static const _ttl = Duration(minutes: 30);
@@ -39,13 +36,6 @@ class CacheService {
     await prefs.setInt(_stationsTsKey, DateTime.now().millisecondsSinceEpoch);
   }
 
-  static Future<void> cachePrices(List<CurrentPrice> prices) async {
-    final prefs = await SharedPreferences.getInstance();
-    final json = jsonEncode(prices.map((p) => p.toJson()).toList());
-    await prefs.setString(_pricesKey, json);
-    await prefs.setInt(_pricesTsKey, DateTime.now().millisecondsSinceEpoch);
-  }
-
   static Future<List<Station>?> getCachedStations() async {
     final prefs = await SharedPreferences.getInstance();
     if (!_isFresh(prefs, _stationsTsKey)) return null;
@@ -54,17 +44,6 @@ class CacheService {
     final list = jsonDecode(json) as List;
     return list
         .map((e) => Station.fromJson(e as Map<String, dynamic>))
-        .toList();
-  }
-
-  static Future<List<CurrentPrice>?> getCachedPrices() async {
-    final prefs = await SharedPreferences.getInstance();
-    if (!_isFresh(prefs, _pricesTsKey)) return null;
-    final json = prefs.getString(_pricesKey);
-    if (json == null) return null;
-    final list = jsonDecode(json) as List;
-    return list
-        .map((e) => CurrentPrice.fromJson(e as Map<String, dynamic>))
         .toList();
   }
 

--- a/lib/services/favorite_service.dart
+++ b/lib/services/favorite_service.dart
@@ -1,26 +1,18 @@
-import 'package:shared_preferences/shared_preferences.dart';
+import 'backend_api_client.dart';
 
 class FavoriteService {
-  static const String _favoritesKey = 'favorite_stations';
+  static final BackendApiClient _client = BackendApiClient();
 
   static Future<Set<String>> getFavorites() async {
-    final prefs = await SharedPreferences.getInstance();
-    final list = prefs.getStringList(_favoritesKey) ?? [];
-    return list.toSet();
+    return _client.getFavorites();
   }
 
   static Future<void> addFavorite(String stationId) async {
-    final prefs = await SharedPreferences.getInstance();
-    final favorites = await getFavorites();
-    favorites.add(stationId);
-    await prefs.setStringList(_favoritesKey, favorites.toList());
+    await _client.addFavorite(stationId);
   }
 
   static Future<void> removeFavorite(String stationId) async {
-    final prefs = await SharedPreferences.getInstance();
-    final favorites = await getFavorites();
-    favorites.remove(stationId);
-    await prefs.setStringList(_favoritesKey, favorites.toList());
+    await _client.removeFavorite(stationId);
   }
 
   static Future<bool> isFavorite(String stationId) async {

--- a/test/models/station_test.dart
+++ b/test/models/station_test.dart
@@ -45,7 +45,7 @@ void main() {
     test('toJson produces correct map', () {
       final station = Station.fromJson(json);
       final output = station.toJson();
-      expect(output, json);
+      expect(output, {...json, 'prices': []});
     });
 
     test('fromJson handles int coordinates', () {


### PR DESCRIPTION
Main migration change:
 - Migrate data layer from Firestore to backend REST API
 - Embed prices in Station model instead of a separate prices list
 - Map fetches stations by bounding box (debounced) instead of client-side filtering
 
 Updated station detail page: 
 - Cooldown tracking moved from Firestore to SharedPreferences
 - Station detail shows two price submission buttons (camera / manual)
 - Price history chart hidden when insufficient data; fixed single-point rendering
 - Removed manual "Refresh stations" setting, not needed when navigating map/pulling is enough to refresh

Sorry for the big PR 🙏 