### PR TITLE
DRIV-0 - Support price estimate

### DIFF
--- a/lib/models/current_price.dart
+++ b/lib/models/current_price.dart
@@ -22,8 +22,10 @@ class CurrentPrice {
   final String stationId;
   final FuelType fuelType;
   final double price;
-  final DateTime updatedAt;
+  final DateTime? updatedAt;
   final int reportCount;
+
+  bool get isEstimate => updatedAt == null;
 
   const CurrentPrice({
     required this.stationId,
@@ -38,7 +40,9 @@ class CurrentPrice {
       stationId: json['stationId'] as String,
       fuelType: FuelType.values.byName(json['fuelType'] as String),
       price: (json['price'] as num).toDouble(),
-      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse(json['updatedAt'] as String)
+          : null,
       reportCount: json['reportCount'] as int,
     );
   }
@@ -51,7 +55,9 @@ class CurrentPrice {
       stationId: stationId,
       fuelType: FuelType.fromBackendString(json['fuelType'] as String),
       price: double.parse(json['price'] as String),
-      updatedAt: DateTime.parse(json['registeredAt'] as String),
+      updatedAt: json['registeredAt'] != null
+          ? DateTime.parse(json['registeredAt'] as String)
+          : null,
       reportCount: 0,
     );
   }
@@ -61,7 +67,7 @@ class CurrentPrice {
       'stationId': stationId,
       'fuelType': fuelType.name,
       'price': price,
-      'updatedAt': updatedAt.toIso8601String(),
+      'updatedAt': updatedAt?.toIso8601String(),
       'reportCount': reportCount,
     };
   }

--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -363,7 +363,9 @@ class StationProvider extends ChangeNotifier {
           if (pa == null && pb == null) return a.name.compareTo(b.name);
           if (pa == null) return 1;
           if (pb == null) return -1;
-          return pb.updatedAt.compareTo(pa.updatedAt);
+          final paTime = pa.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+          final pbTime = pb.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+          return pbTime.compareTo(paTime);
         });
     }
 

--- a/lib/screens/map/widgets/station_bottom_sheet.dart
+++ b/lib/screens/map/widgets/station_bottom_sheet.dart
@@ -296,7 +296,10 @@ class _StationTileState extends State<_StationTile> {
                           if (widget.station.city.isNotEmpty)
                             widget.station.city,
                           ?distanceStr,
-                          if (price != null) timeago.format(price.updatedAt),
+                          if (price != null)
+                            price.isEstimate
+                                ? 'Estimat'
+                                : timeago.format(price.updatedAt!),
                         ].join(' · '),
                         style: AppTextStyles.meta(context),
                       ),

--- a/lib/screens/map/widgets/station_marker.dart
+++ b/lib/screens/map/widgets/station_marker.dart
@@ -162,8 +162,18 @@ class _StationMarkerState extends State<StationMarker> {
   Widget _buildLogoWithPrice(BuildContext context) {
     final price = widget.price!;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final age = DateTime.now().difference(price.updatedAt);
-    final (:label, :color) = _formatAge(context, age);
+
+    final Color borderColor;
+    final String? ageLabel;
+    if (price.isEstimate) {
+      borderColor = AppColors.border(context);
+      ageLabel = null;
+    } else {
+      final age = DateTime.now().difference(price.updatedAt!);
+      final formatted = _formatAge(context, age);
+      borderColor = formatted.color;
+      ageLabel = formatted.label;
+    }
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -178,9 +188,12 @@ class _StationMarkerState extends State<StationMarker> {
               decoration: BoxDecoration(
                 color: AppColors.surfaceElevated(context),
                 shape: BoxShape.circle,
-                border: Border.all(color: color, width: 2.5),
+                border: Border.all(color: borderColor, width: 2.5),
                 boxShadow: [
-                  BoxShadow(color: color.withValues(alpha: 0.3), blurRadius: 6),
+                  BoxShadow(
+                    color: borderColor.withValues(alpha: 0.3),
+                    blurRadius: 6,
+                  ),
                 ],
               ),
               child: _buildBrandImage(
@@ -190,25 +203,47 @@ class _StationMarkerState extends State<StationMarker> {
               ),
             ),
             // Time badge — top right
-            Positioned(
-              top: -4,
-              right: -8,
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-                decoration: BoxDecoration(
-                  color: color,
-                  borderRadius: BorderRadius.circular(6),
+            if (ageLabel != null)
+              Positioned(
+                top: -4,
+                right: -8,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 4,
+                    vertical: 1,
+                  ),
+                  decoration: BoxDecoration(
+                    color: borderColor,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Text(
+                    ageLabel,
+                    style: const TextStyle(
+                      fontSize: 8,
+                      fontWeight: FontWeight.w800,
+                      color: Colors.white,
+                    ),
+                  ),
                 ),
-                child: Text(
-                  label,
-                  style: const TextStyle(
-                    fontSize: 8,
-                    fontWeight: FontWeight.w800,
+              )
+            else if (price.isEstimate)
+              Positioned(
+                top: 0,
+                right: 0,
+                child: Container(
+                  width: 14,
+                  height: 14,
+                  decoration: const BoxDecoration(
+                    color: Colors.orange,
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.question_mark_rounded,
+                    size: 9,
                     color: Colors.white,
                   ),
                 ),
               ),
-            ),
           ],
         ),
         const SizedBox(height: 2),
@@ -240,7 +275,7 @@ class _StationMarkerState extends State<StationMarker> {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              if (widget.isBestPrice)
+              if (widget.isBestPrice && !price.isEstimate)
                 Padding(
                   padding: const EdgeInsets.only(right: 2),
                   child: Icon(

--- a/lib/screens/station_detail/station_detail_screen.dart
+++ b/lib/screens/station_detail/station_detail_screen.dart
@@ -268,6 +268,14 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                 else
                   _PriceBentoGrid(prices: prices),
 
+                if (prices.any((p) => p.isEstimate)) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    'Stasjoner uten prishistorikk viser et estimat basert på andre stasjoner i området',
+                    style: AppTextStyles.meta(context),
+                  ),
+                ],
+
                 const SizedBox(height: 28),
 
                 // ── Report Price ──

--- a/lib/screens/station_detail/station_list_screen.dart
+++ b/lib/screens/station_detail/station_list_screen.dart
@@ -160,6 +160,7 @@ class StationListScreen extends StatelessWidget {
                           distance: distanceStr,
                           price: price?.price,
                           lastUpdated: price?.updatedAt,
+                          isEstimate: price?.isEstimate ?? false,
                           onTap: () {
                             Navigator.pushNamed(
                               context,
@@ -186,6 +187,7 @@ class _StationListTile extends StatefulWidget {
   final String? distance;
   final double? price;
   final DateTime? lastUpdated;
+  final bool isEstimate;
   final VoidCallback onTap;
 
   const _StationListTile({
@@ -196,6 +198,7 @@ class _StationListTile extends StatefulWidget {
     this.distance,
     this.price,
     this.lastUpdated,
+    this.isEstimate = false,
     required this.onTap,
   });
 
@@ -248,14 +251,21 @@ class _StationListTileState extends State<_StationListTile> {
                               TextSpan(text: widget.city),
                             if (widget.city.isNotEmpty &&
                                 (widget.distance != null ||
-                                    widget.lastUpdated != null))
+                                    widget.lastUpdated != null ||
+                                    widget.isEstimate))
                               const TextSpan(text: ' · '),
                             if (widget.distance != null)
                               TextSpan(text: widget.distance),
                             if (widget.distance != null &&
-                                widget.lastUpdated != null)
+                                (widget.lastUpdated != null ||
+                                    widget.isEstimate))
                               const TextSpan(text: ' · '),
-                            if (widget.lastUpdated != null)
+                            if (widget.isEstimate)
+                              TextSpan(
+                                text: 'Estimat',
+                                style: TextStyle(color: Colors.orange),
+                              )
+                            else if (widget.lastUpdated != null)
                               TextSpan(
                                 text: timeago.format(widget.lastUpdated!),
                                 style: TextStyle(

--- a/lib/screens/station_detail/widgets/price_card.dart
+++ b/lib/screens/station_detail/widgets/price_card.dart
@@ -77,10 +77,25 @@ class PriceCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 8),
-          Text(
-            timeago.format(price.updatedAt),
-            style: AppTextStyles.meta(context),
-          ),
+          if (price.isEstimate)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.orange.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(
+                'Estimat',
+                style: AppTextStyles.meta(
+                  context,
+                ).copyWith(color: Colors.orange, fontWeight: FontWeight.w600),
+              ),
+            )
+          else
+            Text(
+              timeago.format(price.updatedAt!),
+              style: AppTextStyles.meta(context),
+            ),
         ],
       ),
     );

--- a/lib/services/mock_data_service.dart
+++ b/lib/services/mock_data_service.dart
@@ -504,7 +504,7 @@ class MockDataService {
           fuelType: price.fuelType,
           price: price.price,
           userId: 'user-mock-1',
-          reportedAt: price.updatedAt,
+          reportedAt: price.updatedAt ?? DateTime.now(),
         ),
       );
       // Add a second older report for variety


### PR DESCRIPTION
Backend returns an estimate based on surround stations if no price has ever been registered (`registered_at` is NULL for these)

This change supports that in the frontend by:
- Showing a question mark on stations with estimates only
- Showing estimate pill and explanation text on station detail screen

<img width="830" height="1678" alt="bilde" src="https://github.com/user-attachments/assets/b3a69806-5121-46e0-9a87-7ba748b8899b" />
<img width="830" height="1678" alt="bilde" src="https://github.com/user-attachments/assets/3f75951d-6a3b-49b5-bf84-17420e9cc10b" />
