### PR TITLE
DRIV-0 - use Firebase Auth popup on the web

### DIFF
--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -19,6 +19,7 @@
 import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -228,6 +229,36 @@ class UserProvider extends ChangeNotifier {
   /// Sign in with Google. Links to anonymous account when possible;
   /// falls back to direct sign-in if the credential is already used.
   Future<void> signInWithGoogle() async {
+    if (kIsWeb) {
+      await _signInWithGoogleWeb();
+    } else {
+      await _signInWithGoogleNative();
+    }
+  }
+
+  Future<void> _signInWithGoogleWeb() async {
+    final provider = GoogleAuthProvider();
+
+    final currentUser = _auth.currentUser;
+    UserCredential result;
+    if (currentUser != null) {
+      try {
+        result = await currentUser.linkWithPopup(provider);
+      } on FirebaseAuthException catch (e) {
+        if (e.code == 'credential-already-in-use') {
+          result = await _auth.signInWithPopup(provider);
+        } else {
+          rethrow;
+        }
+      }
+    } else {
+      result = await _auth.signInWithPopup(provider);
+    }
+
+    await _completeGoogleSignIn(result.user);
+  }
+
+  Future<void> _signInWithGoogleNative() async {
     final GoogleSignInAccount googleUser;
     try {
       googleUser = await _googleSignIn.authenticate();
@@ -261,8 +292,10 @@ class UserProvider extends ChangeNotifier {
       await _auth.signInWithCredential(credential);
     }
 
-    // Use Google display name if available
-    final signedInUser = _auth.currentUser;
+    await _completeGoogleSignIn(_auth.currentUser);
+  }
+
+  Future<void> _completeGoogleSignIn(User? signedInUser) async {
     if (signedInUser == null) {
       throw FirebaseAuthException(
         code: 'sign-in-failed',
@@ -270,8 +303,7 @@ class UserProvider extends ChangeNotifier {
       );
     }
 
-    final displayName =
-        signedInUser.displayName ?? googleUser.displayName ?? 'User';
+    final displayName = signedInUser.displayName ?? 'User';
     // Read existing profile to preserve reportCount/trustScore
     final existing = await FirestoreService.getUserProfile(signedInUser.uid);
     if (existing != null) {

--- a/lib/screens/auth/auth_screen.dart
+++ b/lib/screens/auth/auth_screen.dart
@@ -81,7 +81,8 @@ class _AuthScreenState extends State<AuthScreen> {
         }
       }
     } on FirebaseAuthException catch (e) {
-      if (e.code == 'sign-in-cancelled') {
+      if (e.code == 'sign-in-cancelled' ||
+          e.code == 'popup-closed-by-user') {
       } else {
         setState(() => _error = _friendlyError(context, e.code));
       }


### PR DESCRIPTION
Problem: `google_sign_in v7`'s `authenticate()` throws `UnimplementedError` on web.                                                         
                                                                                                                                        
Solution: Platform-branching in `signInWithGoogle()`:                                                                                   
- Web: Uses Firebase Auth's `signInWithPopup(GoogleAuthProvider()) / linkWithPopup()` directly -> no `google_sign_in` package involved. This opens the standard Google OAuth popup and returns a `UserCredential`.
- Native (Android/iOS): Keeps the existing `google_sign_in.authenticate()` flow unchanged. 