### PR TITLE
DRIV-0 - Fix stations list + counter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,12 +57,14 @@ void main() async {
   // Don't block the UI on auth — UserProvider has sensible defaults
   // (Anonymous user) so the app can render immediately.
   final userProvider = UserProvider();
-  userProvider.initialize();
+  final authReady = userProvider.initialize();
 
-  // Load stations from cache or Firestore aggregate (≤2 reads).
   final stationProvider = StationProvider();
-  stationProvider.loadStations();
-  stationProvider.loadFavorites();
+  // Delay both favorites and station fetch until auth is established.
+  authReady.then((_) {
+    stationProvider.loadFavorites();
+    stationProvider.loadStations();
+  });
 
   runApp(
     MultiProvider(

--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -69,9 +69,16 @@ class StationProvider extends ChangeNotifier {
   }
 
   /// Set the station list filter radius in km. Pass null to show all stations.
-  void setListRadius(double? km) {
+  /// Optionally provide user location to use for the backend fetch and
+  /// client-side distance filter; falls back to any previously stored location.
+  void setListRadius(double? km, {double? userLat, double? userLng}) {
     _listRadiusKm = km;
+    if (userLat != null && userLng != null) {
+      _userLat = userLat;
+      _userLng = userLng;
+    }
     notifyListeners();
+    loadStations();
   }
 
   Future<void> loadFavorites() async {
@@ -292,11 +299,24 @@ class StationProvider extends ChangeNotifier {
     // Use user location if available; fall back to Norway center + full-country radius.
     final lat = _userLat ?? 65.0;
     final lng = _userLng ?? 17.0;
-    final distance = _userLat != null ? 200000.0 : 2500000.0;
+    final double distance;
+    if (_userLat != null && _listRadiusKm != null) {
+      distance = _listRadiusKm! * 1000;
+    } else {
+      distance = 2500000.0;
+    }
     _stations = await client.getStations(
       lat: lat,
       lng: lng,
       distance: distance,
+      sort: switch (_sortMode) {
+        SortMode.cheapest => 'cheapest',
+        SortMode.nearest => 'nearest',
+        SortMode.latest => 'latest',
+      },
+      fuelType: _sortMode == SortMode.cheapest
+          ? _selectedFuelType.backendString
+          : null,
     );
 
     await CacheService.cacheStations(_stations);
@@ -314,61 +334,19 @@ class StationProvider extends ChangeNotifier {
     _selectedFuelType = type;
     _recomputeBestMapStation();
     notifyListeners();
+    if (_sortMode == SortMode.cheapest) {
+      loadStations();
+    }
   }
 
   void setSortMode(SortMode mode) {
     _sortMode = mode;
     notifyListeners();
+    loadStations();
   }
 
-  /// Stations filtered by brand and sorted by the current sort mode.
-  /// Shows all stations; those with prices sort first.
+  /// Returns filtered stations in the order returned by the backend.
   List<Station> sortedStations({double? userLat, double? userLng}) {
-    final all = List<Station>.from(filteredStations);
-
-    switch (_sortMode) {
-      case SortMode.cheapest:
-        all.sort((a, b) {
-          final pa = a.prices[_selectedFuelType];
-          final pb = b.prices[_selectedFuelType];
-          if (pa == null && pb == null) return a.name.compareTo(b.name);
-          if (pa == null) return 1;
-          if (pb == null) return -1;
-          return pa.price.compareTo(pb.price);
-        });
-      case SortMode.nearest:
-        if (userLat != null && userLng != null) {
-          all.sort((a, b) {
-            final da = DistanceService.distanceInMeters(
-              userLat,
-              userLng,
-              a.latitude,
-              a.longitude,
-            );
-            final db = DistanceService.distanceInMeters(
-              userLat,
-              userLng,
-              b.latitude,
-              b.longitude,
-            );
-            return da.compareTo(db);
-          });
-        } else {
-          all.sort((a, b) => a.name.compareTo(b.name));
-        }
-      case SortMode.latest:
-        all.sort((a, b) {
-          final pa = a.prices[_selectedFuelType];
-          final pb = b.prices[_selectedFuelType];
-          if (pa == null && pb == null) return a.name.compareTo(b.name);
-          if (pa == null) return 1;
-          if (pb == null) return -1;
-          final paTime = pa.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
-          final pbTime = pb.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
-          return pbTime.compareTo(paTime);
-        });
-    }
-
-    return all;
+    return filteredStations;
   }
 }

--- a/lib/screens/map/widgets/brand_filter_bar.dart
+++ b/lib/screens/map/widgets/brand_filter_bar.dart
@@ -23,6 +23,7 @@ import '../../../config/app_colors.dart';
 import '../../../widgets/web_constrained.dart';
 import '../../../config/app_text_styles.dart';
 import '../../../l10n/l10n_helper.dart';
+import '../../../providers/location_provider.dart';
 import '../../../providers/station_provider.dart';
 import '../../../providers/user_provider.dart';
 
@@ -114,10 +115,20 @@ class BrandFilterButton extends StatelessWidget {
   }
 }
 
-class _BrandFilterSheet extends StatelessWidget {
+class _BrandFilterSheet extends StatefulWidget {
   final FilterLocation filterLocation;
 
   const _BrandFilterSheet({required this.filterLocation});
+
+  @override
+  State<_BrandFilterSheet> createState() => _BrandFilterSheetState();
+}
+
+class _BrandFilterSheetState extends State<_BrandFilterSheet> {
+  static const _steps = [5, 10, 20, 50, 100, 200, 500, null];
+
+  // Tracks the slider index while dragging; null means use provider value.
+  int? _draggingIndex;
 
   static String _radiusLabel(BuildContext context, double? km) {
     if (km == null) return context.l10n.allOfNorway;
@@ -125,24 +136,28 @@ class _BrandFilterSheet extends StatelessWidget {
     return '${km.round()} km';
   }
 
+  int _indexForKm(double? km) {
+    if (km == null) return _steps.length - 1;
+    final idx = _steps.indexWhere((s) => s != null && (s as num) >= km.round());
+    return idx == -1 ? _steps.length - 1 : idx;
+  }
+
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<StationProvider>();
     final userProvider = context.watch<UserProvider>();
-    final isMap = filterLocation == FilterLocation.map;
+    final locationProvider = context.watch<LocationProvider>();
+    final isMap = widget.filterLocation == FilterLocation.map;
     final brands = isMap
         ? provider.mapAvailableBrands
         : provider.listAvailableBrands;
-    final radiusKm = isMap ? provider.mapRadiusKm : provider.listRadiusKm;
+    final committedKm = isMap ? provider.mapRadiusKm : provider.listRadiusKm;
     final activeColor = AppColors.primaryContainer(context);
     final allowMapRotation = userProvider.allowMapRotation;
 
-    final steps = [5, 10, 20, 50, 100, 200, 500, null];
-    final currentIndex = radiusKm == null
-        ? steps.length - 1
-        : steps.indexWhere((s) => s != null && (s as num) >= radiusKm.round());
-    final sliderValue = (currentIndex == -1 ? steps.length - 1 : currentIndex)
-        .toDouble();
+    final displayIndex = _draggingIndex ?? _indexForKm(committedKm);
+    final displayKm = _steps[displayIndex]?.toDouble();
+    final sliderValue = displayIndex.toDouble();
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -164,7 +179,7 @@ class _BrandFilterSheet extends StatelessWidget {
                 ),
                 const Spacer(),
                 Text(
-                  _radiusLabel(context, radiusKm),
+                  _radiusLabel(context, displayKm),
                   style: AppTextStyles.bodyMedium(context),
                 ),
               ],
@@ -180,15 +195,27 @@ class _BrandFilterSheet extends StatelessWidget {
               child: Slider(
                 value: sliderValue,
                 min: 0,
-                max: (steps.length - 1).toDouble(),
-                divisions: steps.length - 1,
+                max: (_steps.length - 1).toDouble(),
+                divisions: _steps.length - 1,
                 onChanged: (v) {
-                  final idx = v.round();
-                  final km = steps[idx];
+                  setState(() => _draggingIndex = v.round());
                   if (isMap) {
-                    provider.setMapRadius(km?.toDouble());
+                    provider.setMapRadius(_steps[v.round()]?.toDouble());
+                  }
+                },
+                onChangeEnd: (v) {
+                  final idx = v.round();
+                  final km = _steps[idx]?.toDouble();
+                  setState(() => _draggingIndex = null);
+                  if (isMap) {
+                    provider.setMapRadius(km);
                   } else {
-                    provider.setListRadius(km?.toDouble());
+                    final pos = locationProvider.position;
+                    provider.setListRadius(
+                      km,
+                      userLat: pos?.latitude,
+                      userLng: pos?.longitude,
+                    );
                   }
                 },
               ),

--- a/lib/services/backend_api_client.dart
+++ b/lib/services/backend_api_client.dart
@@ -98,15 +98,17 @@ class BackendApiClient {
     required double lat,
     required double lng,
     required double distance,
+    String sort = 'nearest',
+    String? fuelType,
   }) async {
-    final data = await get(
-      '/stations/',
-      queryParams: {
-        'lat': lat.toString(),
-        'lng': lng.toString(),
-        'distance': distance.toString(),
-      },
-    );
+    final params = <String, String>{
+      'lat': lat.toString(),
+      'lng': lng.toString(),
+      'distance': distance.toString(),
+      'sort': sort,
+    };
+    if (fuelType != null) params['fuelType'] = fuelType;
+    final data = await get('/stations/', queryParams: params);
     final raw = data['stations'] as List<dynamic>;
     return [
       for (final item in raw)

--- a/lib/widgets/floating_pill_nav.dart
+++ b/lib/widgets/floating_pill_nav.dart
@@ -271,6 +271,7 @@ class _FloatingPillNavState extends State<FloatingPillNav> {
                             onTap: () {
                               setState(() => _currentIndex = 2);
                               context.read<UserProvider>().reloadUser();
+                              context.read<UserProvider>().refreshProfile();
                             },
                           ),
                         ],


### PR DESCRIPTION
Fixes two issues:
- Station list was not loading and was not filtering/ordering correctly, and is now fixed by stripping away all legacy filtering and relying on the backend to filter and sort.
- Registration counter wasn't updating after a new registration. Fix: Profile page now refreshes when navigating to it, getting the latest counter.