### PR TITLE
KAN-178 - Update price on map after price registration

### DIFF
--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -265,6 +265,12 @@ class StationProvider extends ChangeNotifier {
 
     try {
       await _fetchFromBackend();
+      final refreshed = {for (final s in _stations) s.id: s};
+      for (final id in _mapStationCache.keys.toList()) {
+        final updated = refreshed[id];
+        if (updated != null) _mapStationCache[id] = updated;
+      }
+      _recomputeBestMapStation();
     } catch (e) {
       debugPrint('Failed to refresh stations: $e');
       rethrow;


### PR DESCRIPTION
After a price registration the new price was immeditately visible on the map, only on the station page.

NOTE A more efficient state setup for stations and price will come in a different PR. There should be no need to update the whole station like we do here.