### PR TITLE
DRIV-176 - fix camera issues on chrome

### DIFF
--- a/lib/screens/contribute/contribute_screen.dart
+++ b/lib/screens/contribute/contribute_screen.dart
@@ -27,6 +27,7 @@ import '../../models/fuel_type.dart';
 import '../../models/station.dart';
 import '../../providers/location_provider.dart';
 import '../../providers/station_provider.dart';
+import '../../providers/user_provider.dart';
 import '../../services/distance_service.dart';
 import '../../widgets/brand_logo.dart';
 
@@ -497,11 +498,17 @@ class _PriceEntryStepState extends State<_PriceEntryStep> {
     super.dispose();
   }
 
-  void _submit() {
+  Future<void> _submit() async {
     final text = _controller.text.trim();
     if (text.isEmpty) return;
     final price = double.tryParse(text);
     if (price == null) return;
+
+    final userProvider = context.read<UserProvider>();
+    if (!userProvider.isAuthenticated) {
+      await Navigator.pushNamed(context, AppRoutes.auth);
+      if (!mounted || !userProvider.isAuthenticated) return;
+    }
 
     // Navigate to the existing submit price screen with the station
     Navigator.pushNamed(

--- a/lib/screens/map/widgets/nearby_station_banner.dart
+++ b/lib/screens/map/widgets/nearby_station_banner.dart
@@ -27,6 +27,7 @@ import '../../../l10n/l10n_helper.dart';
 import '../../../models/station.dart';
 import '../../../providers/location_provider.dart';
 import '../../../providers/station_provider.dart';
+import '../../../providers/user_provider.dart';
 import '../../../services/distance_service.dart';
 
 /// Distance threshold in meters to show the "nearby station" banner.
@@ -131,7 +132,14 @@ class _NearbyStationBannerState extends State<NearbyStationBanner> {
               _BannerAction(
                 icon: Icons.check_circle,
                 color: const Color(0xFF4CAF50),
-                onTap: () {
+                onTap: () async {
+                  final userProvider = context.read<UserProvider>();
+                  if (!userProvider.isAuthenticated) {
+                    await Navigator.pushNamed(context, AppRoutes.auth);
+                    if (!context.mounted || !userProvider.isAuthenticated) {
+                      return;
+                    }
+                  }
                   Navigator.pushNamed(
                     context,
                     AppRoutes.submitPrice,

--- a/lib/screens/station_detail/station_detail_screen.dart
+++ b/lib/screens/station_detail/station_detail_screen.dart
@@ -293,10 +293,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                         onPressed: () async {
                           final userProvider = context.read<UserProvider>();
                           if (!userProvider.isAuthenticated) {
-                            await Navigator.pushNamed(
-                              context,
-                              AppRoutes.auth,
-                            );
+                            await Navigator.pushNamed(context, AppRoutes.auth);
                             if (!context.mounted ||
                                 !userProvider.isAuthenticated) {
                               return;
@@ -322,10 +319,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                         onPressed: () async {
                           final userProvider = context.read<UserProvider>();
                           if (!userProvider.isAuthenticated) {
-                            await Navigator.pushNamed(
-                              context,
-                              AppRoutes.auth,
-                            );
+                            await Navigator.pushNamed(context, AppRoutes.auth);
                             if (!context.mounted ||
                                 !userProvider.isAuthenticated) {
                               return;

--- a/lib/screens/station_detail/station_detail_screen.dart
+++ b/lib/screens/station_detail/station_detail_screen.dart
@@ -291,13 +291,24 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                         icon: Icons.camera_alt_outlined,
                         label: 'Med kamera',
                         onPressed: () async {
+                          final userProvider = context.read<UserProvider>();
+                          if (!userProvider.isAuthenticated) {
+                            await Navigator.pushNamed(
+                              context,
+                              AppRoutes.auth,
+                            );
+                            if (!context.mounted ||
+                                !userProvider.isAuthenticated) {
+                              return;
+                            }
+                          }
                           final priceProvider = context.read<PriceProvider>();
                           await Navigator.pushNamed(
                             context,
                             AppRoutes.submitPrice,
                             arguments: widget.station,
                           );
-                          if (mounted) {
+                          if (context.mounted) {
                             priceProvider.loadHistory(widget.station.id);
                           }
                         },
@@ -309,6 +320,17 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                         icon: Icons.edit_outlined,
                         label: 'Manuelt',
                         onPressed: () async {
+                          final userProvider = context.read<UserProvider>();
+                          if (!userProvider.isAuthenticated) {
+                            await Navigator.pushNamed(
+                              context,
+                              AppRoutes.auth,
+                            );
+                            if (!context.mounted ||
+                                !userProvider.isAuthenticated) {
+                              return;
+                            }
+                          }
                           final priceProvider = context.read<PriceProvider>();
                           await Navigator.push(
                             context,
@@ -317,7 +339,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                                   SubmitPriceScreen(station: widget.station),
                             ),
                           );
-                          if (mounted) {
+                          if (context.mounted) {
                             priceProvider.loadHistory(widget.station.id);
                           }
                         },

--- a/lib/screens/submit_price/price_capture_screen.dart
+++ b/lib/screens/submit_price/price_capture_screen.dart
@@ -95,9 +95,7 @@ class _PriceCaptureScreenState extends State<PriceCaptureScreen> {
     ImageMetadata metadata;
 
     if (kIsWeb) {
-      final picked = await ImagePicker().pickImage(
-        source: ImageSource.gallery,
-      );
+      final picked = await ImagePicker().pickImage(source: ImageSource.gallery);
       if (picked == null) {
         debugPrint('[$_tag] User cancelled gallery');
         if (!mounted) return;
@@ -128,7 +126,10 @@ class _PriceCaptureScreenState extends State<PriceCaptureScreen> {
     await _cropAndScan(imageBytes, metadata);
   }
 
-  Future<void> _cropAndScan(Uint8List imageBytes, ImageMetadata metadata) async {
+  Future<void> _cropAndScan(
+    Uint8List imageBytes,
+    ImageMetadata metadata,
+  ) async {
     if (!mounted) return;
 
     final croppedBytes = await Navigator.push<dynamic>(

--- a/lib/screens/submit_price/price_capture_screen.dart
+++ b/lib/screens/submit_price/price_capture_screen.dart
@@ -87,35 +87,55 @@ class _PriceCaptureScreenState extends State<PriceCaptureScreen> {
       'within24h=${metadata.isTakenWithin24Hours}',
     );
 
-    await _cropAndScan(File(picked.path), metadata);
+    await _cropAndScan(originalBytes, metadata);
   }
 
   Future<void> _handleGallery() async {
-    final pickResult = await NativeImagePickerService.pickImageFromGallery();
-    if (pickResult == null) {
-      debugPrint('[$_tag] User cancelled gallery');
-      if (!mounted) return;
-      // Re-open camera so user can try again.
-      _openCamera();
-      return;
+    Uint8List imageBytes;
+    ImageMetadata metadata;
+
+    if (kIsWeb) {
+      final picked = await ImagePicker().pickImage(
+        source: ImageSource.gallery,
+      );
+      if (picked == null) {
+        debugPrint('[$_tag] User cancelled gallery');
+        if (!mounted) return;
+        _openCamera();
+        return;
+      }
+      imageBytes = await picked.readAsBytes();
+      metadata = await ImageMetadataService.extractMetadata(imageBytes);
+    } else {
+      final pickResult = await NativeImagePickerService.pickImageFromGallery();
+      if (pickResult == null) {
+        debugPrint('[$_tag] User cancelled gallery');
+        if (!mounted) return;
+        _openCamera();
+        return;
+      }
+      debugPrint('[$_tag] Gallery image: ${pickResult.path}');
+      imageBytes = await File(pickResult.path).readAsBytes();
+      metadata = pickResult.metadata;
     }
 
-    debugPrint('[$_tag] Gallery image: ${pickResult.path}');
     debugPrint(
-      '[$_tag] Native EXIF: hasLocation=${pickResult.metadata.hasLocation}, '
-      'hasDateTime=${pickResult.metadata.hasDateTime}, '
-      'within24h=${pickResult.metadata.isTakenWithin24Hours}',
+      '[$_tag] Gallery EXIF: hasLocation=${metadata.hasLocation}, '
+      'hasDateTime=${metadata.hasDateTime}, '
+      'within24h=${metadata.isTakenWithin24Hours}',
     );
 
-    await _cropAndScan(File(pickResult.path), pickResult.metadata);
+    await _cropAndScan(imageBytes, metadata);
   }
 
-  Future<void> _cropAndScan(File imageFile, ImageMetadata metadata) async {
+  Future<void> _cropAndScan(Uint8List imageBytes, ImageMetadata metadata) async {
     if (!mounted) return;
 
     final croppedBytes = await Navigator.push<dynamic>(
       context,
-      MaterialPageRoute(builder: (_) => ManualCropScreen(imageFile: imageFile)),
+      MaterialPageRoute(
+        builder: (_) => ManualCropScreen(imageBytes: imageBytes),
+      ),
     );
 
     if (croppedBytes == null || !mounted) {

--- a/lib/screens/submit_price/widgets/camera_with_stencil_screen.dart
+++ b/lib/screens/submit_price/widgets/camera_with_stencil_screen.dart
@@ -83,8 +83,14 @@ class _CameraWithStencilScreenState extends State<CameraWithStencilScreen> {
         return;
       }
 
-      final minZoom = await controller.getMinZoomLevel();
-      final maxZoom = await controller.getMaxZoomLevel();
+      var minZoom = 1.0;
+      var maxZoom = 1.0;
+      try {
+        minZoom = await controller.getMinZoomLevel();
+        maxZoom = await controller.getMaxZoomLevel();
+      } catch (_) {
+        // Zoom not supported (e.g. web) — keep defaults.
+      }
 
       setState(() {
         _controller = controller;
@@ -99,7 +105,11 @@ class _CameraWithStencilScreenState extends State<CameraWithStencilScreen> {
 
   Future<void> _setZoom(double zoom) async {
     final clamped = zoom.clamp(_minZoom, _maxZoom);
-    await _controller?.setZoomLevel(clamped);
+    try {
+      await _controller?.setZoomLevel(clamped);
+    } catch (_) {
+      return; // Zoom not supported (e.g. web).
+    }
     setState(() => _currentZoom = clamped);
   }
 

--- a/lib/screens/submit_price/widgets/manual_crop_screen.dart
+++ b/lib/screens/submit_price/widgets/manual_crop_screen.dart
@@ -16,8 +16,6 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import 'dart:io';
-
 import 'package:crop_your_image/crop_your_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -25,12 +23,12 @@ import 'package:flutter/material.dart';
 import '../../../l10n/l10n_helper.dart';
 
 class ManualCropScreen extends StatefulWidget {
-  final File imageFile;
+  final Uint8List imageBytes;
   final Rect? initialArea;
 
   const ManualCropScreen({
     super.key,
-    required this.imageFile,
+    required this.imageBytes,
     this.initialArea,
   });
 
@@ -40,20 +38,7 @@ class ManualCropScreen extends StatefulWidget {
 
 class _ManualCropScreenState extends State<ManualCropScreen> {
   final _cropController = CropController();
-  Uint8List? _imageBytes;
   bool _isCropping = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadImage();
-  }
-
-  Future<void> _loadImage() async {
-    final bytes = await widget.imageFile.readAsBytes();
-    if (!mounted) return;
-    setState(() => _imageBytes = bytes);
-  }
 
   void _onCrop() {
     setState(() => _isCropping = true);
@@ -91,9 +76,7 @@ class _ManualCropScreenState extends State<ManualCropScreen> {
           ),
         ],
       ),
-      body: _imageBytes == null
-          ? const Center(child: CircularProgressIndicator())
-          : Column(
+      body: Column(
               children: [
                 Padding(
                   padding: const EdgeInsets.all(12),
@@ -104,7 +87,7 @@ class _ManualCropScreenState extends State<ManualCropScreen> {
                 ),
                 Expanded(
                   child: Crop(
-                    image: _imageBytes!,
+                    image: widget.imageBytes,
                     controller: _cropController,
                     onCropped: _onCropped,
                     initialRectBuilder: InitialRectBuilder.withSizeAndRatio(
@@ -122,3 +105,4 @@ class _ManualCropScreenState extends State<ManualCropScreen> {
     );
   }
 }
+

--- a/lib/screens/submit_price/widgets/manual_crop_screen.dart
+++ b/lib/screens/submit_price/widgets/manual_crop_screen.dart
@@ -77,32 +77,30 @@ class _ManualCropScreenState extends State<ManualCropScreen> {
         ],
       ),
       body: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Text(
-                    context.l10n.dragToSelect,
-                    style: const TextStyle(fontSize: 14, color: Colors.grey),
-                  ),
-                ),
-                Expanded(
-                  child: Crop(
-                    image: widget.imageBytes,
-                    controller: _cropController,
-                    onCropped: _onCropped,
-                    initialRectBuilder: InitialRectBuilder.withSizeAndRatio(
-                      size: 0.25,
-                      aspectRatio: 2 / 3,
-                    ),
-                    maskColor: Colors.black54,
-                    cornerDotBuilder: (size, edgeAlignment) => DotControl(
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                  ),
-                ),
-              ],
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Text(
+              context.l10n.dragToSelect,
+              style: const TextStyle(fontSize: 14, color: Colors.grey),
             ),
+          ),
+          Expanded(
+            child: Crop(
+              image: widget.imageBytes,
+              controller: _cropController,
+              onCropped: _onCropped,
+              initialRectBuilder: InitialRectBuilder.withSizeAndRatio(
+                size: 0.25,
+                aspectRatio: 2 / 3,
+              ),
+              maskColor: Colors.black54,
+              cornerDotBuilder: (size, edgeAlignment) =>
+                  DotControl(color: Theme.of(context).colorScheme.primary),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
-

--- a/lib/screens/submit_price/widgets/scan_price_button.dart
+++ b/lib/screens/submit_price/widgets/scan_price_button.dart
@@ -171,9 +171,7 @@ class _ScanPriceButtonState extends State<ScanPriceButton> {
     ImageMetadata metadata;
 
     if (kIsWeb) {
-      final picked = await ImagePicker().pickImage(
-        source: ImageSource.gallery,
-      );
+      final picked = await ImagePicker().pickImage(source: ImageSource.gallery);
       if (picked == null) {
         debugPrint('[$_tag] User cancelled gallery');
         return;
@@ -201,7 +199,10 @@ class _ScanPriceButtonState extends State<ScanPriceButton> {
   }
 
   /// Common flow: crop → scan → confirm → callback.
-  Future<void> _cropAndScan(Uint8List imageBytes, ImageMetadata metadata) async {
+  Future<void> _cropAndScan(
+    Uint8List imageBytes,
+    ImageMetadata metadata,
+  ) async {
     if (!mounted) return;
 
     final croppedBytes = await Navigator.push<dynamic>(

--- a/lib/screens/submit_price/widgets/scan_price_button.dart
+++ b/lib/screens/submit_price/widgets/scan_price_button.dart
@@ -159,36 +159,56 @@ class _ScanPriceButtonState extends State<ScanPriceButton> {
       'hasDateTime=${metadata.hasDateTime}, within24h=${metadata.isTakenWithin24Hours}',
     );
 
-    await _cropAndScan(File(picked.path), metadata);
+    await _cropAndScan(originalBytes, metadata);
   }
 
-  /// Pick from gallery using native method channel to preserve GPS EXIF data.
+  /// Pick from gallery. Uses native channel on mobile (preserves GPS EXIF),
+  /// falls back to ImagePicker on web.
   Future<void> _pickFromGallery() async {
     Navigator.pop(context);
 
-    final pickResult = await NativeImagePickerService.pickImageFromGallery();
-    if (pickResult == null) {
-      debugPrint('[$_tag] User cancelled gallery');
-      return;
+    Uint8List imageBytes;
+    ImageMetadata metadata;
+
+    if (kIsWeb) {
+      final picked = await ImagePicker().pickImage(
+        source: ImageSource.gallery,
+      );
+      if (picked == null) {
+        debugPrint('[$_tag] User cancelled gallery');
+        return;
+      }
+      imageBytes = await picked.readAsBytes();
+      metadata = await ImageMetadataService.extractMetadata(imageBytes);
+    } else {
+      final pickResult = await NativeImagePickerService.pickImageFromGallery();
+      if (pickResult == null) {
+        debugPrint('[$_tag] User cancelled gallery');
+        return;
+      }
+      debugPrint('[$_tag] Gallery image: ${pickResult.path}');
+      imageBytes = await File(pickResult.path).readAsBytes();
+      metadata = pickResult.metadata;
     }
 
-    debugPrint('[$_tag] Gallery image: ${pickResult.path}');
     debugPrint(
-      '[$_tag] Native EXIF: hasLocation=${pickResult.metadata.hasLocation}, '
-      'hasDateTime=${pickResult.metadata.hasDateTime}, '
-      'within24h=${pickResult.metadata.isTakenWithin24Hours}',
+      '[$_tag] Gallery EXIF: hasLocation=${metadata.hasLocation}, '
+      'hasDateTime=${metadata.hasDateTime}, '
+      'within24h=${metadata.isTakenWithin24Hours}',
     );
 
-    await _cropAndScan(File(pickResult.path), pickResult.metadata);
+    await _cropAndScan(imageBytes, metadata);
   }
 
   /// Common flow: crop → scan → confirm → callback.
-  Future<void> _cropAndScan(File imageFile, ImageMetadata metadata) async {
+  Future<void> _cropAndScan(Uint8List imageBytes, ImageMetadata metadata) async {
     if (!mounted) return;
 
     final croppedBytes = await Navigator.push<dynamic>(
       context,
-      MaterialPageRoute(builder: (_) => ManualCropScreen(imageFile: imageFile)),
+      MaterialPageRoute(
+        builder: (_) => ManualCropScreen(imageBytes: imageBytes),
+      ),
     );
 
     if (croppedBytes == null || !mounted) {

--- a/lib/services/claude_vision_service.dart
+++ b/lib/services/claude_vision_service.dart
@@ -19,10 +19,10 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:image/image.dart' as img;
 
 import '../models/fuel_type.dart';
 import 'backend_api_client.dart';
+import 'image_compressor.dart';
 
 const _tag = 'ClaudeVision';
 
@@ -35,29 +35,13 @@ class ClaudeVisionService {
 
   /// Compress and resize image bytes for the API call.
   ///
-  /// Returns JPEG bytes with reduced resolution.
+  /// Uses browser Canvas on web (fast), image package in isolate on mobile.
   static Future<Uint8List> compressImage(Uint8List imageBytes) async {
-    return compute(_compressInIsolate, imageBytes);
-  }
-
-  static Uint8List _compressInIsolate(Uint8List bytes) {
-    final original = img.decodeImage(bytes);
-    if (original == null) throw Exception('Failed to decode image');
-
-    // Resize if larger than max dimension
-    img.Image resized;
-    if (original.width > _maxDimension || original.height > _maxDimension) {
-      if (original.width >= original.height) {
-        resized = img.copyResize(original, width: _maxDimension);
-      } else {
-        resized = img.copyResize(original, height: _maxDimension);
-      }
-    } else {
-      resized = original;
-    }
-
-    // Encode as JPEG with reduced quality
-    return Uint8List.fromList(img.encodeJpg(resized, quality: _jpegQuality));
+    return compressImagePlatform(
+      imageBytes,
+      maxDimension: _maxDimension,
+      quality: _jpegQuality,
+    );
   }
 
   /// Send the image to the backend and extract fuel prices.

--- a/lib/services/image_compressor.dart
+++ b/lib/services/image_compressor.dart
@@ -1,0 +1,20 @@
+/*
+* A crowdsourced platform for real-time fuel price monitoring in Norway
+* Copyright (C) 2026  Tsotne Karchava & Contributors
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export 'image_compressor_io.dart'
+    if (dart.library.html) 'image_compressor_web.dart';

--- a/lib/services/image_compressor_io.dart
+++ b/lib/services/image_compressor_io.dart
@@ -1,0 +1,51 @@
+/*
+* A crowdsourced platform for real-time fuel price monitoring in Norway
+* Copyright (C) 2026  Tsotne Karchava & Contributors
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+
+/// Compress and resize image bytes using the `image` package (runs in isolate).
+Future<Uint8List> compressImagePlatform(
+  Uint8List bytes, {
+  int maxDimension = 800,
+  int quality = 70,
+}) {
+  return compute(
+    _compress,
+    (bytes, maxDimension, quality),
+  );
+}
+
+Uint8List _compress((Uint8List, int, int) args) {
+  final (bytes, maxDimension, quality) = args;
+  final original = img.decodeImage(bytes);
+  if (original == null) throw Exception('Failed to decode image');
+
+  img.Image resized;
+  if (original.width > maxDimension || original.height > maxDimension) {
+    if (original.width >= original.height) {
+      resized = img.copyResize(original, width: maxDimension);
+    } else {
+      resized = img.copyResize(original, height: maxDimension);
+    }
+  } else {
+    resized = original;
+  }
+
+  return Uint8List.fromList(img.encodeJpg(resized, quality: quality));
+}

--- a/lib/services/image_compressor_io.dart
+++ b/lib/services/image_compressor_io.dart
@@ -25,10 +25,7 @@ Future<Uint8List> compressImagePlatform(
   int maxDimension = 800,
   int quality = 70,
 }) {
-  return compute(
-    _compress,
-    (bytes, maxDimension, quality),
-  );
+  return compute(_compress, (bytes, maxDimension, quality));
 }
 
 Uint8List _compress((Uint8List, int, int) args) {

--- a/lib/services/image_compressor_web.dart
+++ b/lib/services/image_compressor_web.dart
@@ -1,0 +1,64 @@
+/*
+* A crowdsourced platform for real-time fuel price monitoring in Norway
+* Copyright (C) 2026  Tsotne Karchava & Contributors
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import 'dart:async';
+import 'dart:convert';
+// ignore: avoid_web_libraries_in_flutter, deprecated_member_use
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+/// Compress and resize image bytes using the browser's native Canvas API.
+Future<Uint8List> compressImagePlatform(
+  Uint8List bytes, {
+  int maxDimension = 800,
+  int quality = 70,
+}) async {
+  final blob = html.Blob([bytes]);
+  final url = html.Url.createObjectUrlFromBlob(blob);
+
+  try {
+    // Load image via an <img> element.
+    final imgEl = html.ImageElement()..src = url;
+    await imgEl.onLoad.first;
+
+    // Calculate target dimensions.
+    var width = imgEl.naturalWidth;
+    var height = imgEl.naturalHeight;
+    if (width > maxDimension || height > maxDimension) {
+      if (width >= height) {
+        height = (height * maxDimension / width).round();
+        width = maxDimension;
+      } else {
+        width = (width * maxDimension / height).round();
+        height = maxDimension;
+      }
+    }
+
+    // Draw scaled image onto a canvas.
+    final canvas = html.CanvasElement(width: width, height: height);
+    final ctx = canvas.context2D;
+    ctx.drawImageScaled(imgEl, 0, 0, width, height);
+
+    // Export as JPEG data URL and decode the base64 portion.
+    final dataUrl = canvas.toDataUrl('image/jpeg', quality / 100);
+    final base64Data = dataUrl.split(',')[1];
+    return Uint8List.fromList(base64Decode(base64Data));
+  } finally {
+    html.Url.revokeObjectUrl(url);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -817,10 +817,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1134,10 +1134,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   timeago:
     dependency: "direct main"
     description:


### PR DESCRIPTION
This PR does the following:

- Fixed camera crash on web: Wrapped zoom API calls in try-catch since the web camera plugin doesn't support zoom queries
- Fixed gallery picker on web: Fall back to `ImagePicker` (file explorer) on web instead of the Android-only native method channel.
- Changed ManualCropScreen to accept bytes: Replaced File parameter with `Uint8List` so the crop screen works cross-platform.
-  Added login gate for price submission: All 4 entry points (camera, manual, contribute, nearby banner) now redirect to the auth screen if the user isn't logged in.
- Fixed slow image compression on web: Added platform-specific compressor — uses browser Canvas API on web instead of the pure-Dart image package that blocks the main thread.