### PR TITLE
DRIV-186 - add a tip for pinch-to-zoom, add 10.0 and 20.0 camera zoom presets

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -327,5 +327,8 @@
   "emailNotVerified": "Verify your email",
   "emailNotVerifiedSubtitle": "Check your inbox for a verification link",
   "resendVerificationEmail": "Resend email",
-  "verificationEmailSent": "Verification email sent"
+  "verificationEmailSent": "Verification email sent",
+
+  "cameraZoomTipTitle": "Zoom Tip",
+  "cameraZoomTipBody": "Use pinch-to-zoom to zoom in closer to the price sign. You can also tap the zoom buttons below the viewfinder."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1735,6 +1735,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Verification email sent'**
   String get verificationEmailSent;
+
+  /// No description provided for @cameraZoomTipTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Zoom Tip'**
+  String get cameraZoomTipTitle;
+
+  /// No description provided for @cameraZoomTipBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Use pinch-to-zoom to zoom in closer to the price sign. You can also tap the zoom buttons below the viewfinder.'**
+  String get cameraZoomTipBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -903,4 +903,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get verificationEmailSent => 'Verification email sent';
+
+  @override
+  String get cameraZoomTipTitle => 'Zoom Tip';
+
+  @override
+  String get cameraZoomTipBody =>
+      'Use pinch-to-zoom to zoom in closer to the price sign. You can also tap the zoom buttons below the viewfinder.';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -909,4 +909,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get verificationEmailSent => 'Bekreftelses-e-post sendt';
+
+  @override
+  String get cameraZoomTipTitle => 'Zoom-tips';
+
+  @override
+  String get cameraZoomTipBody =>
+      'Bruk knip-for-å-zoome for å zoome nærmere prisskiltet. Du kan også trykke på zoom-knappene under søkeren.';
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -304,5 +304,8 @@
   "emailNotVerified": "Bekreft e-posten din",
   "emailNotVerifiedSubtitle": "Sjekk innboksen din for en bekreftelseslenke",
   "resendVerificationEmail": "Send på nytt",
-  "verificationEmailSent": "Bekreftelses-e-post sendt"
+  "verificationEmailSent": "Bekreftelses-e-post sendt",
+
+  "cameraZoomTipTitle": "Zoom-tips",
+  "cameraZoomTipBody": "Bruk knip-for-å-zoome for å zoome nærmere prisskiltet. Du kan også trykke på zoom-knappene under søkeren."
 }

--- a/lib/screens/submit_price/widgets/camera_with_stencil_screen.dart
+++ b/lib/screens/submit_price/widgets/camera_with_stencil_screen.dart
@@ -18,6 +18,7 @@
 
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../l10n/l10n_helper.dart';
 
@@ -50,7 +51,8 @@ class _CameraWithStencilScreenState extends State<CameraWithStencilScreen> {
   double _currentZoom = 1.0;
   double _baseZoom = 1.0;
 
-  static const _zoomPresets = [1.0, 2.0];
+  static const _zoomPresets = [1.0, 2.0, 10.0, 20.0];
+  static const _zoomTipSeenKey = 'camera_zoom_tip_seen';
 
   @override
   void initState() {
@@ -97,10 +99,38 @@ class _CameraWithStencilScreenState extends State<CameraWithStencilScreen> {
         _minZoom = minZoom;
         _maxZoom = maxZoom;
       });
+
+      _showZoomTipIfNeeded();
     } catch (e) {
       if (!mounted) return;
       setState(() => _error = e.toString());
     }
+  }
+
+  Future<void> _showZoomTipIfNeeded() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool(_zoomTipSeenKey) ?? false) return;
+    if (!mounted) return;
+
+    await prefs.setBool(_zoomTipSeenKey, true);
+
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        final l10n = context.l10n;
+        return AlertDialog(
+          title: Text(l10n.cameraZoomTipTitle),
+          content: Text(l10n.cameraZoomTipBody),
+          actions: [
+            FilledButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(l10n.gotIt),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   Future<void> _setZoom(double zoom) async {


### PR DESCRIPTION
This PR adds the following:

- One-time popup during first camera opening for giving tip regaring pinch-to-zoom 
- adds 10x and 20x presets (Presets that exceed the device's max are simply not rendered. So for example if a device
   only supports up to 10x, the user will see buttons for 1x, 2x, and 10x - the 20x button won't appear.)

<img width="493" height="903" alt="image" src="https://github.com/user-attachments/assets/3c109390-25b7-40f1-a94e-a1b8c74d5709" />
