### PR TITLE
DRIV-0 - Optimize station and price loading

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,10 +62,16 @@ void main() async {
   final authReady = userProvider.initialize();
 
   final stationProvider = StationProvider();
-  // Delay both favorites and station fetch until auth is established.
+  // Start station initialization (loads cache, checks last-updated).
+  // The authenticated fetch is deferred until auth is ready.
+  stationProvider.initialize();
+
   authReady.then((_) {
+    stationProvider.onAuthReady();
     stationProvider.loadFavorites();
-    stationProvider.loadStations();
+    // Preload the sorted station list so it's ready when the user
+    // navigates to the list screen.
+    stationProvider.loadSortedStations();
   });
 
   runApp(

--- a/lib/models/station.dart
+++ b/lib/models/station.dart
@@ -57,6 +57,20 @@ class Station {
     this.prices = const {},
   });
 
+  /// Returns a copy of this station with the given prices merged in.
+  Station copyWithPrices(Map<FuelType, CurrentPrice> newPrices) {
+    return Station(
+      id: id,
+      name: name,
+      brand: brand,
+      address: address,
+      city: city,
+      latitude: latitude,
+      longitude: longitude,
+      prices: newPrices,
+    );
+  }
+
   factory Station.fromJson(Map<String, dynamic> json) {
     final rawPrices = json['prices'] as List<dynamic>? ?? [];
     final prices = <FuelType, CurrentPrice>{};
@@ -98,6 +112,21 @@ class Station {
       latitude: (location['lat'] as num).toDouble(),
       longitude: (location['lng'] as num).toDouble(),
       prices: prices,
+    );
+  }
+
+  /// Parses a station from the `/stations/all` endpoint (no prices).
+  factory Station.fromBaseJson(Map<String, dynamic> json) {
+    final provider = json['provider'] as String;
+    final location = json['location'] as Map<String, dynamic>;
+    return Station(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      brand: _providerToDisplayName[provider] ?? provider,
+      address: json['address'] as String,
+      city: json['city'] as String,
+      latitude: (location['lat'] as num).toDouble(),
+      longitude: (location['lng'] as num).toDouble(),
     );
   }
 

--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -16,6 +16,8 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../models/fuel_type.dart';
@@ -30,11 +32,23 @@ import '../widgets/brand_logo.dart';
 enum SortMode { cheapest, nearest, latest }
 
 class StationProvider extends ChangeNotifier {
-  List<Station> _stations = [];
+  /// All stations keyed by ID — the single source of truth.
+  Map<String, Station> _allStations = {};
 
-  // Separate state for the map view, populated by bbox fetches.
-  // Keyed by station ID so results accumulate across navigations.
-  final Map<String, Station> _mapStationCache = {};
+  /// Tracks when prices were last fetched per station.
+  final Map<String, DateTime> _priceFetchedAt = {};
+
+  /// Station IDs currently being fetched — prevents duplicate requests.
+  final Set<String> _priceLoadingIds = {};
+
+  static const _priceTtl = Duration(minutes: 5);
+  static const _priceBatchSize = 50;
+
+  /// Stations fetched from `GET /stations` for list view (sorted by backend).
+  /// Used for cheapest/latest sort modes which need server-side ordering.
+  List<Station> _listStations = [];
+  bool _isListLoading = false;
+
   String? _bestMapStationId;
   FuelType _selectedFuelType = FuelType.petrol95;
   SortMode _sortMode = SortMode.cheapest;
@@ -42,6 +56,9 @@ class StationProvider extends ChangeNotifier {
   bool _isLoading = false;
   bool _showFavoritesOnly = false;
   Set<String> _favoriteStationIds = {};
+
+  /// Completer for waiting on auth before fetching stations.
+  Completer<void>? _authCompleter;
 
   /// Map radius in km. null means show all stations ("All of Norway").
   double? _mapRadiusKm;
@@ -52,7 +69,7 @@ class StationProvider extends ChangeNotifier {
   double? _userLat;
   double? _userLng;
 
-  List<Station> get stations => _stations;
+  List<Station> get stations => _allStations.values.toList();
   FuelType get selectedFuelType => _selectedFuelType;
   SortMode get sortMode => _sortMode;
   Set<String> get selectedBrands => _selectedBrands;
@@ -62,25 +79,137 @@ class StationProvider extends ChangeNotifier {
   double? get listRadiusKm => _listRadiusKm;
   bool get showFavoritesOnly => _showFavoritesOnly;
   Set<String> get favoriteStationIds => _favoriteStationIds;
+  bool get isListLoading => _isListLoading;
 
-  /// Set the map filter radius in km. Pass null to show all stations.
-  void setMapRadius(double? km) {
-    _mapRadiusKm = km;
+  /// Look up a station by ID.
+  Station? getStation(String id) => _allStations[id];
+
+  // ── Initialization ────────────────────────────────────────────────────────
+
+  /// Initialize station data. Loads from cache first, then checks if
+  /// the backend has newer data via `/stations/last-updated`.
+  /// Call `onAuthReady()` once auth is established so the provider
+  /// can fetch from the backend if needed.
+  Future<void> initialize() async {
+    _isLoading = true;
     notifyListeners();
-  }
 
-  /// Set the station list filter radius in km. Pass null to show all stations.
-  /// Optionally provide user location to use for the backend fetch and
-  /// client-side distance filter; falls back to any previously stored location.
-  void setListRadius(double? km, {double? userLat, double? userLng}) {
-    _listRadiusKm = km;
-    if (userLat != null && userLng != null) {
-      _userLat = userLat;
-      _userLng = userLng;
+    _authCompleter = Completer<void>();
+
+    try {
+      // 1. Load cached stations immediately for fast UI.
+      CacheService.clearLegacyCache(); // one-time migration, not awaited
+      final cached = await CacheService.getCachedAllStations();
+      if (cached != null) {
+        _allStations = {for (final s in cached) s.id: s};
+        notifyListeners();
+      }
+
+      // 2. Check server timestamp (no auth needed).
+      final client = BackendApiClient();
+      DateTime? serverLastUpdated;
+      try {
+        serverLastUpdated = await client.getStationsLastUpdated();
+      } catch (e) {
+        debugPrint('Failed to check last-updated: $e');
+      }
+
+      // 3. Compare with stored timestamp.
+      final storedLastUpdated = await CacheService.getStoredLastUpdatedAt();
+      final needsFetch =
+          serverLastUpdated != null &&
+          (storedLastUpdated == null || serverLastUpdated != storedLastUpdated);
+
+      if (needsFetch) {
+        // Wait for auth before making the authenticated call.
+        await _authCompleter!.future;
+        final stations = await client.getAllStations();
+        _allStations = {for (final s in stations) s.id: s};
+        await CacheService.cacheAllStations(stations, serverLastUpdated);
+      }
+
+      // Load brand logos.
+      try {
+        final logos = await FirestoreService.getBrandLogos();
+        BrandLogo.setRemoteLogos(logos);
+      } catch (_) {
+        // Non-critical — local assets still work.
+      }
+    } catch (e) {
+      debugPrint('Failed to initialize stations: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
     }
-    notifyListeners();
-    loadStations();
   }
+
+  /// Signal that Firebase auth is ready. Unblocks `initialize()` if
+  /// it's waiting to fetch stations from the backend.
+  void onAuthReady() {
+    if (_authCompleter != null && !_authCompleter!.isCompleted) {
+      _authCompleter!.complete();
+    }
+  }
+
+  // ── Price loading ─────────────────────────────────────────────────────────
+
+  /// Fetch prices for the given station IDs.
+  /// Skips stations whose prices are still fresh or already being fetched.
+  Future<void> loadPricesForStations(List<String> stationIds) async {
+    final now = DateTime.now();
+    final needed = stationIds.where((id) {
+      if (_priceLoadingIds.contains(id)) return false;
+      final fetchedAt = _priceFetchedAt[id];
+      if (fetchedAt != null && now.difference(fetchedAt) < _priceTtl) {
+        return false;
+      }
+      return _allStations.containsKey(id);
+    }).toList();
+
+    if (needed.isEmpty) return;
+
+    _priceLoadingIds.addAll(needed);
+    notifyListeners();
+
+    try {
+      final client = BackendApiClient();
+      // Batch into chunks to avoid URL length limits.
+      for (var i = 0; i < needed.length; i += _priceBatchSize) {
+        final chunk = needed.sublist(
+          i,
+          i + _priceBatchSize > needed.length
+              ? needed.length
+              : i + _priceBatchSize,
+        );
+        final priceMap = await client.getStationPrices(chunk);
+        for (final entry in priceMap.entries) {
+          final station = _allStations[entry.key];
+          if (station != null) {
+            _allStations[entry.key] = station.copyWithPrices(entry.value);
+            _priceFetchedAt[entry.key] = DateTime.now();
+          }
+        }
+        // Also mark stations that returned no prices as fetched.
+        for (final id in chunk) {
+          _priceFetchedAt.putIfAbsent(id, () => DateTime.now());
+        }
+        _priceLoadingIds.removeAll(chunk);
+        _recomputeBestMapStation();
+        notifyListeners();
+      }
+    } catch (e) {
+      debugPrint('Failed to load prices: $e');
+    } finally {
+      final hadLoading = _priceLoadingIds.any(needed.contains);
+      _priceLoadingIds.removeAll(needed);
+      if (hadLoading) notifyListeners();
+    }
+  }
+
+  /// True if a price fetch is currently in-flight for this station.
+  bool isPriceLoading(String id) => _priceLoadingIds.contains(id);
+
+  // ── Favorites ─────────────────────────────────────────────────────────────
 
   Future<void> loadFavorites() async {
     _favoriteStationIds = await FavoriteService.getFavorites();
@@ -120,16 +249,33 @@ class StationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Set the user's location for distance-based filtering.
+  // ── Location & Radius ─────────────────────────────────────────────────────
+
   void setUserLocation(double lat, double lng) {
     _userLat = lat;
     _userLng = lng;
     notifyListeners();
   }
 
-  /// Filter stations by a given radius in km.
+  void setMapRadius(double? km) {
+    _mapRadiusKm = km;
+    notifyListeners();
+  }
+
+  void setListRadius(double? km, {double? userLat, double? userLng}) {
+    _listRadiusKm = km;
+    if (userLat != null && userLng != null) {
+      _userLat = userLat;
+      _userLng = userLng;
+    }
+    notifyListeners();
+    loadSortedStations();
+  }
+
+  // ── Filtering ─────────────────────────────────────────────────────────────
+
   Iterable<Station> _filterByRadius(double? radiusKm) {
-    Iterable<Station> result = _stations;
+    Iterable<Station> result = _allStations.values;
 
     if (radiusKm != null && _userLat != null && _userLng != null) {
       final radiusMeters = radiusKm * 1000;
@@ -145,6 +291,16 @@ class StationProvider extends ChangeNotifier {
     }
 
     return result;
+  }
+
+  Iterable<Station> _applyBrandAndFavFilter(Iterable<Station> source) {
+    if (_selectedBrands.isNotEmpty) {
+      source = source.where((s) => _selectedBrands.contains(s.brand));
+    }
+    if (_showFavoritesOnly) {
+      source = source.where((s) => _favoriteStationIds.contains(s.id));
+    }
+    return source;
   }
 
   /// Brands available within the map radius.
@@ -167,33 +323,12 @@ class StationProvider extends ChangeNotifier {
 
   /// Stations filtered by station list radius and selected brands.
   List<Station> get filteredStations {
-    Iterable<Station> result = _filterByRadius(_listRadiusKm);
-
-    if (_selectedBrands.isNotEmpty) {
-      result = result.where((s) => _selectedBrands.contains(s.brand));
-    }
-
-    if (_showFavoritesOnly) {
-      result = result.where((s) => _favoriteStationIds.contains(s.id));
-    }
-
-    return result.toList();
+    return _applyBrandAndFavFilter(_filterByRadius(_listRadiusKm)).toList();
   }
 
   /// Stations filtered by map radius and selected brands.
-  /// Used by the map to show stations.
   List<Station> get brandFilteredStations {
-    Iterable<Station> result = _filterByRadius(_mapRadiusKm);
-
-    if (_selectedBrands.isNotEmpty) {
-      result = result.where((s) => _selectedBrands.contains(s.brand));
-    }
-
-    if (_showFavoritesOnly) {
-      result = result.where((s) => _favoriteStationIds.contains(s.id));
-    }
-
-    return result.toList();
+    return _applyBrandAndFavFilter(_filterByRadius(_mapRadiusKm)).toList();
   }
 
   String? get bestMapStationId => _bestMapStationId;
@@ -201,7 +336,7 @@ class StationProvider extends ChangeNotifier {
   void _recomputeBestMapStation() {
     String? bestId;
     double bestPrice = double.infinity;
-    for (final station in _mapStationCache.values) {
+    for (final station in _allStations.values) {
       final p = station.prices[_selectedFuelType];
       if (p != null && p.price < bestPrice) {
         bestPrice = p.price;
@@ -211,21 +346,7 @@ class StationProvider extends ChangeNotifier {
     _bestMapStationId = bestId;
   }
 
-  /// All stations fetched via bbox, filtered by brand/favorites.
-  /// Accumulates across navigations — stations are never evicted.
-  List<Station> get mapStations {
-    Iterable<Station> result = _mapStationCache.values;
-
-    if (_selectedBrands.isNotEmpty) {
-      result = result.where((s) => _selectedBrands.contains(s.brand));
-    }
-
-    if (_showFavoritesOnly) {
-      result = result.where((s) => _favoriteStationIds.contains(s.id));
-    }
-
-    return result.toList();
-  }
+  // ── Sorting & Fuel Type ───────────────────────────────────────────────────
 
   void toggleBrand(String brand) {
     _selectedBrands = Set.of(_selectedBrands);
@@ -242,35 +363,141 @@ class StationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Load stations and prices from the backend API.
-  /// Called on app startup.
-  Future<void> loadStations() async {
-    _isLoading = true;
+  void setFuelType(FuelType type) {
+    _selectedFuelType = type;
+    _recomputeBestMapStation();
+    notifyListeners();
+    if (_sortMode != SortMode.nearest) {
+      loadSortedStations();
+    }
+  }
+
+  void setSortMode(SortMode mode) {
+    _sortMode = mode;
+    notifyListeners();
+    loadSortedStations();
+  }
+
+  /// Fetch stations with prices from `GET /stations`, pre-sorted by the
+  /// backend. Used for the station list's cheapest/latest tabs.
+  Future<void> loadSortedStations() async {
+    _isListLoading = true;
     notifyListeners();
 
     try {
-      await _fetchFromBackend();
+      final client = BackendApiClient();
+      final lat = _userLat ?? 65.0;
+      final lng = _userLng ?? 17.0;
+      final double distance;
+      if (_userLat != null && _listRadiusKm != null) {
+        distance = _listRadiusKm! * 1000;
+      } else {
+        distance = 2500000.0;
+      }
+      _listStations = await client.getStations(
+        lat: lat,
+        lng: lng,
+        distance: distance,
+        sort: switch (_sortMode) {
+          SortMode.cheapest => 'cheapest',
+          SortMode.nearest => 'nearest',
+          SortMode.latest => 'latest',
+        },
+        fuelType: _sortMode == SortMode.nearest
+            ? null
+            : _selectedFuelType.backendString,
+      );
+
+      // Merge fetched prices into _allStations so other screens benefit.
+      for (final s in _listStations) {
+        if (s.prices.isNotEmpty) {
+          final existing = _allStations[s.id];
+          if (existing != null) {
+            _allStations[s.id] = existing.copyWithPrices(s.prices);
+            _priceFetchedAt[s.id] = DateTime.now();
+          }
+        }
+      }
+      _recomputeBestMapStation();
     } catch (e) {
-      debugPrint('Failed to load stations: $e');
+      debugPrint('Failed to load sorted stations: $e');
     } finally {
-      _isLoading = false;
+      _isListLoading = false;
       notifyListeners();
     }
   }
 
-  /// Re-fetch stations and prices from the backend.
+  /// Returns stations for the list view.
+  /// For cheapest/latest: uses `_listStations` (server-sorted with prices).
+  /// For nearest: sorts `_allStations` client-side by distance.
+  List<Station> sortedStations({double? userLat, double? userLng}) {
+    if (_sortMode != SortMode.nearest) {
+      // Use server-sorted list, applying brand/favorites filter.
+      return _applyBrandAndFavFilter(_listStations).toList();
+    }
+
+    // Nearest: sort locally from all stations.
+    final list = filteredStations;
+    final lat = userLat ?? _userLat;
+    final lng = userLng ?? _userLng;
+
+    if (lat != null && lng != null) {
+      list.sort((a, b) {
+        final da = DistanceService.distanceInMeters(
+          lat,
+          lng,
+          a.latitude,
+          a.longitude,
+        );
+        final db = DistanceService.distanceInMeters(
+          lat,
+          lng,
+          b.latitude,
+          b.longitude,
+        );
+        return da.compareTo(db);
+      });
+    }
+    return list;
+  }
+
+  // ── Search ────────────────────────────────────────────────────────────────
+
+  /// Search all stations client-side by name, brand, address, or city.
+  List<Station> searchStations(String query) {
+    if (query.isEmpty) return [];
+    final lower = query.toLowerCase();
+    return _allStations.values.where((s) {
+      return s.name.toLowerCase().contains(lower) ||
+          s.brand.toLowerCase().contains(lower) ||
+          s.address.toLowerCase().contains(lower) ||
+          s.city.toLowerCase().contains(lower);
+    }).toList();
+  }
+
+  // ── Refresh ───────────────────────────────────────────────────────────────
+
+  /// Re-fetch all stations unconditionally and clear price cache.
   Future<void> refreshStations() async {
     _isLoading = true;
     notifyListeners();
 
     try {
-      await _fetchFromBackend();
-      final refreshed = {for (final s in _stations) s.id: s};
-      for (final id in _mapStationCache.keys.toList()) {
-        final updated = refreshed[id];
-        if (updated != null) _mapStationCache[id] = updated;
+      final client = BackendApiClient();
+      final stations = await client.getAllStations();
+      _allStations = {for (final s in stations) s.id: s};
+      _priceFetchedAt.clear();
+      _listStations = [];
+
+      final serverLastUpdated = await client.getStationsLastUpdated();
+      if (serverLastUpdated != null) {
+        await CacheService.cacheAllStations(stations, serverLastUpdated);
       }
-      _recomputeBestMapStation();
+
+      try {
+        final logos = await FirestoreService.getBrandLogos();
+        BrandLogo.setRemoteLogos(logos);
+      } catch (_) {}
     } catch (e) {
       debugPrint('Failed to refresh stations: $e');
       rethrow;
@@ -278,85 +505,5 @@ class StationProvider extends ChangeNotifier {
       _isLoading = false;
       notifyListeners();
     }
-  }
-
-  Future<void> loadStationsByBbox({
-    required double minLat,
-    required double minLng,
-    required double maxLat,
-    required double maxLng,
-  }) async {
-    try {
-      final client = BackendApiClient();
-      final fetched = await client.getStationsByBbox(
-        minLat: minLat,
-        minLng: minLng,
-        maxLat: maxLat,
-        maxLng: maxLng,
-      );
-      for (final station in fetched) {
-        _mapStationCache[station.id] = station;
-      }
-      _recomputeBestMapStation();
-      notifyListeners();
-    } catch (e) {
-      debugPrint('Failed to load stations by bbox: $e');
-    }
-  }
-
-  Future<void> _fetchFromBackend() async {
-    final client = BackendApiClient();
-    // Use user location if available; fall back to Norway center + full-country radius.
-    final lat = _userLat ?? 65.0;
-    final lng = _userLng ?? 17.0;
-    final double distance;
-    if (_userLat != null && _listRadiusKm != null) {
-      distance = _listRadiusKm! * 1000;
-    } else {
-      distance = 2500000.0;
-    }
-    _stations = await client.getStations(
-      lat: lat,
-      lng: lng,
-      distance: distance,
-      sort: switch (_sortMode) {
-        SortMode.cheapest => 'cheapest',
-        SortMode.nearest => 'nearest',
-        SortMode.latest => 'latest',
-      },
-      fuelType: _sortMode == SortMode.cheapest
-          ? _selectedFuelType.backendString
-          : null,
-    );
-
-    await CacheService.cacheStations(_stations);
-
-    // Load remote brand logos and update BrandLogo cache
-    try {
-      final logos = await FirestoreService.getBrandLogos();
-      BrandLogo.setRemoteLogos(logos);
-    } catch (_) {
-      // Non-critical — local assets still work
-    }
-  }
-
-  void setFuelType(FuelType type) {
-    _selectedFuelType = type;
-    _recomputeBestMapStation();
-    notifyListeners();
-    if (_sortMode == SortMode.cheapest) {
-      loadStations();
-    }
-  }
-
-  void setSortMode(SortMode mode) {
-    _sortMode = mode;
-    notifyListeners();
-    loadStations();
-  }
-
-  /// Returns filtered stations in the order returned by the backend.
-  List<Station> sortedStations({double? userLat, double? userLng}) {
-    return filteredStations;
   }
 }

--- a/lib/screens/map/map_screen.dart
+++ b/lib/screens/map/map_screen.dart
@@ -21,28 +21,27 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 
 import '../../config/app_colors.dart';
 import '../../config/app_text_styles.dart';
-import '../../l10n/l10n_helper.dart';
 import '../../config/constants.dart';
 import '../../config/routes.dart';
+import '../../l10n/l10n_helper.dart';
 import '../../models/station.dart';
 import '../../providers/location_provider.dart';
 import '../../providers/station_provider.dart';
 import '../../providers/user_provider.dart';
-import '../../services/backend_api_client.dart';
-import 'package:geolocator/geolocator.dart';
 import '../../services/location_service.dart';
 import '../../widgets/brand_logo.dart';
+import '../../widgets/web_constrained.dart';
 import 'widgets/brand_filter_bar.dart';
 import 'widgets/fuel_filter_bar.dart';
 import 'widgets/nearby_station_banner.dart';
 import 'widgets/station_marker.dart';
-import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
-import '../../widgets/web_constrained.dart';
 
 class MapScreen extends StatefulWidget {
   const MapScreen({super.key});
@@ -51,21 +50,26 @@ class MapScreen extends StatefulWidget {
   State<MapScreen> createState() => _MapScreenState();
 }
 
+const _kClusterRadiusPx = 95.0;
+const _kClusterMaxZoom = 12.0;
+
 class _MapScreenState extends State<MapScreen> {
   final MapController _mapController = MapController();
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocus = FocusNode();
   bool _hasCenteredOnUser = false;
   bool _hasSetUserLocation = false;
+  bool _hasTriggeredInitialPriceLoad = false;
   bool _isSearching = false;
   String _searchQuery = '';
-  List<Station> _searchApiResults = [];
-  bool _searchLoading = false;
-  Timer? _searchDebounce;
-  LatLngBounds? _visibleBounds;
+  Timer? _priceDebounce;
   bool? _previousAllowMapRotation;
-  Timer? _bboxDebounce;
-  bool _hasLoadedInitialBbox = false;
+
+  // Station IDs currently rendered inside a cluster bubble. Populated by the
+  // `MarkerClusterLayerOptions.builder` callback as it's invoked per cluster
+  // during the library's render pass, and cleared in `_onMapEvent` so each
+  // new camera state starts from a clean slate.
+  final Set<String> _clusteredStationIds = {};
 
   @override
   void initState() {
@@ -75,23 +79,7 @@ class _MapScreenState extends State<MapScreen> {
     });
     _searchController.addListener(() {
       final query = _searchController.text.trim();
-      _searchDebounce?.cancel();
-      if (query.isEmpty) {
-        setState(() {
-          _searchQuery = query;
-          _searchApiResults = [];
-          _searchLoading = false;
-        });
-      } else {
-        setState(() {
-          _searchQuery = query;
-          _searchLoading = true;
-        });
-        _searchDebounce = Timer(
-          const Duration(milliseconds: 500),
-          () => _fetchSearchResults(query),
-        );
-      }
+      setState(() => _searchQuery = query);
     });
     _searchFocus.addListener(() {
       setState(() => _isSearching = _searchFocus.hasFocus);
@@ -100,8 +88,7 @@ class _MapScreenState extends State<MapScreen> {
 
   @override
   void dispose() {
-    _bboxDebounce?.cancel();
-    _searchDebounce?.cancel();
+    _priceDebounce?.cancel();
     _searchController.dispose();
     _searchFocus.dispose();
     super.dispose();
@@ -111,6 +98,12 @@ class _MapScreenState extends State<MapScreen> {
     final pos = context.read<LocationProvider>().position;
     if (pos != null) {
       _mapController.move(LatLng(pos.latitude, pos.longitude), 13);
+      // On web, programmatic moves don't reliably fire onPositionChanged,
+      // so trigger a price load explicitly after the camera has settled.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _onMapEvent(_mapController.camera, false);
+      });
     }
   }
 
@@ -131,55 +124,50 @@ class _MapScreenState extends State<MapScreen> {
     _searchController.clear();
     _searchFocus.unfocus();
     _mapController.move(LatLng(station.latitude, station.longitude), 15);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _onMapEvent(_mapController.camera, false);
+    });
     Navigator.pushNamed(context, AppRoutes.stationDetail, arguments: station);
   }
 
-  Future<void> _fetchSearchResults(String query) async {
-    try {
-      final results = await BackendApiClient().searchStations(query);
-      if (mounted) {
-        setState(() {
-          _searchApiResults = results;
-          _searchLoading = false;
-        });
-      }
-    } catch (_) {
-      if (mounted) {
-        setState(() {
-          _searchApiResults = [];
-          _searchLoading = false;
-        });
-      }
-    }
-  }
-
   void _onMapEvent(MapCamera camera, bool hasGesture) {
-    final bounds = camera.visibleBounds;
-    if (_visibleBounds != bounds) {
-      _visibleBounds = bounds;
-      _bboxDebounce?.cancel();
-      if (!_hasLoadedInitialBbox) {
-        // First position event — load immediately without debounce so
-        // stations appear even if onMapReady fired before layout.
-        _hasLoadedInitialBbox = true;
-        context.read<StationProvider>().loadStationsByBbox(
-          minLat: bounds.south,
-          minLng: bounds.west,
-          maxLat: bounds.north,
-          maxLng: bounds.east,
-        );
-      } else {
-        _bboxDebounce = Timer(const Duration(milliseconds: 600), () {
-          if (!mounted) return;
-          context.read<StationProvider>().loadStationsByBbox(
-            minLat: bounds.south,
-            minLng: bounds.west,
-            maxLat: bounds.north,
-            maxLng: bounds.east,
-          );
-        });
+    // Invalidate cluster memberships from the previous camera state. The
+    // rebuild that follows this event (on the next frame) will repopulate
+    // `_clusteredStationIds` via the cluster `builder` callback, so by the
+    // time the 500 ms debounce fires the set reflects the current render.
+    //
+    // flutter_map emits this callback synchronously from `moveRaw` BEFORE
+    // scheduling the rebuild (see flutter_map's `map_controller_impl.dart`),
+    // which makes clearing here safe.
+    _clusteredStationIds.clear();
+    _priceDebounce?.cancel();
+    _priceDebounce = Timer(const Duration(milliseconds: 500), () {
+      if (!mounted) return;
+      final stationProvider = context.read<StationProvider>();
+      final all = stationProvider.brandFilteredStations;
+      if (all.isEmpty) return;
+
+      final bounds = camera.visibleBounds;
+      final visibleIds = <String>[];
+      final unclusteredVisibleIds = <String>[];
+      for (final s in all) {
+        if (s.latitude < bounds.south || s.latitude > bounds.north) continue;
+        if (s.longitude < bounds.west || s.longitude > bounds.east) continue;
+        visibleIds.add(s.id);
+        if (!_clusteredStationIds.contains(s.id)) {
+          unclusteredVisibleIds.add(s.id);
+        }
       }
-    }
+
+      // If only a handful of stations are visible, just fetch for all of them
+      // regardless of cluster state — every marker should show a price.
+      // Otherwise fetch only for the individually-rendered (unclustered) ones,
+      // since cluster bubbles never display prices.
+      final ids = visibleIds.length <= 10 ? visibleIds : unclusteredVisibleIds;
+      if (ids.isEmpty) return;
+      stationProvider.loadPricesForStations(ids);
+    });
   }
 
   @override
@@ -228,8 +216,25 @@ class _MapScreenState extends State<MapScreen> {
       }
     }
 
-    final filtered = stationProvider.mapStations;
+    final filtered = stationProvider.brandFilteredStations;
     final bestStationId = stationProvider.bestMapStationId;
+
+    if (filtered.isNotEmpty && !_hasTriggeredInitialPriceLoad) {
+      _hasTriggeredInitialPriceLoad = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        try {
+          _onMapEvent(_mapController.camera, false);
+        } catch (_) {
+          // Map controller not ready yet — the onMapReady nudge will cover it.
+        }
+      });
+    }
+
+    // Client-side search results.
+    final searchResults = _searchQuery.isNotEmpty
+        ? stationProvider.searchStations(_searchQuery)
+        : <Station>[];
 
     final tileUrl = isDark
         ? 'https://cartodb-basemaps-a.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png'
@@ -257,20 +262,6 @@ class _MapScreenState extends State<MapScreen> {
                       : InteractiveFlag.all & ~InteractiveFlag.rotate,
                 ),
                 onMapReady: () {
-                  // Defer bounds read until after layout so the camera
-                  // has the correct viewport size (not 0×0).
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    if (!mounted) return;
-                    final bounds = _mapController.camera.visibleBounds;
-                    _visibleBounds = bounds;
-                    _hasLoadedInitialBbox = true;
-                    context.read<StationProvider>().loadStationsByBbox(
-                      minLat: bounds.south,
-                      minLng: bounds.west,
-                      maxLat: bounds.north,
-                      maxLng: bounds.east,
-                    );
-                  });
                   // Nudge tiles to load — flutter_map may not render
                   // tiles when built behind a dialog or IndexedStack.
                   Future.delayed(const Duration(milliseconds: 200), () {
@@ -328,25 +319,31 @@ class _MapScreenState extends State<MapScreen> {
                 ),
                 MarkerClusterLayerWidget(
                   options: MarkerClusterLayerOptions(
-                    maxClusterRadius: 95,
+                    maxClusterRadius: _kClusterRadiusPx.toInt(),
                     size: const Size(40, 40),
                     alignment: Alignment.center,
                     padding: const EdgeInsets.all(50),
-                    maxZoom: 15,
+                    maxZoom: _kClusterMaxZoom,
                     showPolygon: false,
                     markers: filtered.map((station) {
                       final price =
                           station.prices[stationProvider.selectedFuelType];
                       final isBest = station.id == bestStationId;
                       return Marker(
+                        // Key on the outer Marker so `builder:` below can
+                        // recover the station id for each clustered marker.
+                        key: ValueKey(station.id),
                         point: LatLng(station.latitude, station.longitude),
                         width: 72,
-                        height: price != null ? 72 : 48,
+                        height: 72,
                         child: StationMarker(
                           key: ValueKey(station.id),
                           station: station,
                           price: price,
                           isBestPrice: isBest,
+                          isLoadingPrice: stationProvider.isPriceLoading(
+                            station.id,
+                          ),
                           onTap: () {
                             Navigator.pushNamed(
                               context,
@@ -358,6 +355,16 @@ class _MapScreenState extends State<MapScreen> {
                       );
                     }).toList(),
                     builder: (context, markers) {
+                      // Record which stations are rendered inside this
+                      // cluster bubble. The set is cleared on each map event
+                      // (see `_onMapEvent`), so by the time the price-fetch
+                      // debounce fires it holds the current clustered set.
+                      for (final m in markers) {
+                        final k = m.key;
+                        if (k is ValueKey<String>) {
+                          _clusteredStationIds.add(k.value);
+                        }
+                      }
                       return Container(
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(20),
@@ -450,16 +457,7 @@ class _MapScreenState extends State<MapScreen> {
                             ),
                           ),
                           const SizedBox(width: 10),
-                          if (_searchLoading)
-                            SizedBox(
-                              width: 18,
-                              height: 18,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: AppColors.textMuted(context),
-                              ),
-                            )
-                          else if (_searchQuery.isNotEmpty)
+                          if (_searchQuery.isNotEmpty)
                             GestureDetector(
                               onTap: () {
                                 _searchController.clear();
@@ -539,7 +537,7 @@ class _MapScreenState extends State<MapScreen> {
           // Search results dropdown
           if (_isSearching &&
               _searchQuery.isNotEmpty &&
-              _searchApiResults.isNotEmpty)
+              searchResults.isNotEmpty)
             Positioned(
               top: topPadding + 60,
               left: 16,
@@ -569,14 +567,14 @@ class _MapScreenState extends State<MapScreen> {
                       child: ListView.separated(
                         shrinkWrap: true,
                         padding: const EdgeInsets.symmetric(vertical: 4),
-                        itemCount: _searchApiResults.length,
+                        itemCount: searchResults.length,
                         separatorBuilder: (_, _) => Divider(
                           height: 1,
                           indent: 56,
                           color: AppColors.border(context),
                         ),
                         itemBuilder: (context, index) {
-                          final station = _searchApiResults[index];
+                          final station = searchResults[index];
                           return _SearchResultTile(
                             station: station,
                             onTap: () => _selectSearchResult(station),
@@ -590,10 +588,7 @@ class _MapScreenState extends State<MapScreen> {
             ),
 
           // "No results" message
-          if (_isSearching &&
-              _searchQuery.isNotEmpty &&
-              !_searchLoading &&
-              _searchApiResults.isEmpty)
+          if (_isSearching && _searchQuery.isNotEmpty && searchResults.isEmpty)
             Positioned(
               top: topPadding + 60,
               left: 16,

--- a/lib/screens/map/widgets/station_marker.dart
+++ b/lib/screens/map/widgets/station_marker.dart
@@ -28,6 +28,7 @@ class StationMarker extends StatefulWidget {
   final Station station;
   final CurrentPrice? price;
   final bool isBestPrice;
+  final bool isLoadingPrice;
   final VoidCallback onTap;
 
   const StationMarker({
@@ -35,6 +36,7 @@ class StationMarker extends StatefulWidget {
     required this.station,
     this.price,
     this.isBestPrice = false,
+    this.isLoadingPrice = false,
     required this.onTap,
   });
 
@@ -151,21 +153,19 @@ class _StationMarkerState extends State<StationMarker> {
       child: AnimatedScale(
         scale: _isPressed ? 0.93 : 1.0,
         duration: const Duration(milliseconds: 80),
-        child: widget.price != null
-            ? _buildLogoWithPrice(context)
-            : _buildCircleMarker(context),
+        child: _buildLogoWithPrice(context),
       ),
     );
   }
 
   /// Logo circle with freshness-colored border, time badge, and price tag.
   Widget _buildLogoWithPrice(BuildContext context) {
-    final price = widget.price!;
+    final price = widget.price;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     final Color borderColor;
     final String? ageLabel;
-    if (price.isEstimate) {
+    if (price == null || price.isEstimate) {
       borderColor = AppColors.border(context);
       ageLabel = null;
     } else {
@@ -226,7 +226,7 @@ class _StationMarkerState extends State<StationMarker> {
                   ),
                 ),
               )
-            else if (price.isEstimate)
+            else if (price != null && price.isEstimate)
               Positioned(
                 top: 0,
                 right: 0,
@@ -247,97 +247,89 @@ class _StationMarkerState extends State<StationMarker> {
           ],
         ),
         const SizedBox(height: 2),
-        // Price tag
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-          decoration: BoxDecoration(
-            color: widget.isBestPrice
-                ? AppColors.primaryContainer(context)
-                : (isDark ? AppColors.darkSurfaceHigh : Colors.white),
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: widget.isBestPrice
-                  ? AppColors.primaryContainer(context)
-                  : AppColors.border(context),
-              width: widget.isBestPrice ? 1 : 0.5,
-            ),
-            boxShadow: [
-              BoxShadow(
-                color: widget.isBestPrice
-                    ? AppColors.primaryContainer(
-                        context,
-                      ).withValues(alpha: 0.35)
-                    : Colors.black.withValues(alpha: 0.1),
-                blurRadius: widget.isBestPrice ? 8 : 4,
-              ),
-            ],
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (widget.isBestPrice && !price.isEstimate)
-                Padding(
-                  padding: const EdgeInsets.only(right: 2),
-                  child: Icon(
-                    Icons.star_rounded,
-                    size: 10,
-                    color: isDark ? AppColors.darkBackground : Colors.white,
-                  ),
-                ),
-              Text(
-                price.price.toStringAsFixed(2),
-                style: TextStyle(
-                  fontSize: 10,
-                  fontWeight: FontWeight.w700,
-                  color: widget.isBestPrice
-                      ? (isDark ? AppColors.darkBackground : Colors.white)
-                      : AppColors.textPrimary(context),
-                ),
-              ),
-            ],
-          ),
-        ),
+        // Price tag — always visible. Shows price when loaded, a spinner
+        // while fetching, and a dash placeholder when the backend has no
+        // price for this station.
+        _buildPricePill(context, price, isDark),
       ],
     );
   }
 
-  /// No price — plain circle with logo or initials.
-  Widget _buildCircleMarker(BuildContext context) {
-    return AnimatedOpacity(
-      opacity: _isPressed ? 0.85 : 1.0,
-      duration: const Duration(milliseconds: 80),
-      child: SizedBox(
-        width: 48,
-        height: 48,
-        child: Stack(
-          alignment: Alignment.center,
-          children: [
-            Container(
-              width: 48,
-              height: 48,
-              decoration: BoxDecoration(
-                color: AppColors.surfaceElevated(context),
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: AppColors.border(context),
-                  width: 0.5,
-                ),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.1),
-                    blurRadius: 8,
-                    offset: const Offset(0, 2),
-                  ),
-                ],
+  Widget _buildPricePill(
+    BuildContext context,
+    CurrentPrice? price,
+    bool isDark,
+  ) {
+    final hasPrice = price != null;
+    final highlight = widget.isBestPrice && hasPrice;
+    final textColor = highlight
+        ? (isDark ? AppColors.darkBackground : Colors.white)
+        : AppColors.textPrimary(context);
+
+    // Min width so the pill is at least wide enough to fit a two-decimal
+    // price like "99.99" with the star prefix for best-price.
+    const pillMinWidth = 44.0;
+
+    return Container(
+      constraints: const BoxConstraints(minWidth: pillMinWidth),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: highlight
+            ? AppColors.primaryContainer(context)
+            : (isDark ? AppColors.darkSurfaceHigh : Colors.white),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: highlight
+              ? AppColors.primaryContainer(context)
+              : AppColors.border(context),
+          width: highlight ? 1 : 0.5,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: highlight
+                ? AppColors.primaryContainer(context).withValues(alpha: 0.35)
+                : Colors.black.withValues(alpha: 0.1),
+            blurRadius: highlight ? 8 : 4,
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (hasPrice) ...[
+            if (highlight && !price.isEstimate)
+              Padding(
+                padding: const EdgeInsets.only(right: 2),
+                child: Icon(Icons.star_rounded, size: 10, color: textColor),
+              ),
+            Text(
+              price.price.toStringAsFixed(2),
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                color: textColor,
               ),
             ),
+          ] else if (widget.isLoadingPrice)
             SizedBox(
-              width: 32,
-              height: 32,
-              child: _buildBrandImage(context, size: 32),
+              width: 10,
+              height: 10,
+              child: CircularProgressIndicator(
+                strokeWidth: 1.5,
+                color: AppColors.textMuted(context),
+              ),
+            )
+          else
+            Text(
+              '—',
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                color: AppColors.textMuted(context),
+              ),
             ),
-          ],
-        ),
+        ],
       ),
     );
   }

--- a/lib/screens/station_detail/station_detail_screen.dart
+++ b/lib/screens/station_detail/station_detail_screen.dart
@@ -63,6 +63,9 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
       final provider = context.read<PriceProvider>();
       provider.clear();
       provider.loadHistory(widget.station.id);
+      context.read<StationProvider>().loadPricesForStations([
+        widget.station.id,
+      ]);
     });
   }
 
@@ -120,10 +123,8 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
     final stationProvider = context.watch<StationProvider>();
     final priceProvider = context.watch<PriceProvider>();
     final userProvider = context.watch<UserProvider>();
-    final station = stationProvider.stations.firstWhere(
-      (s) => s.id == widget.station.id,
-      orElse: () => widget.station,
-    );
+    final station =
+        stationProvider.getStation(widget.station.id) ?? widget.station;
     final prices = station.prices.values.toList();
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final activeColor = AppColors.primaryContainer(context);

--- a/lib/screens/station_detail/station_list_screen.dart
+++ b/lib/screens/station_detail/station_list_screen.dart
@@ -110,12 +110,14 @@ class StationListScreen extends StatelessWidget {
             ),
           ),
           Expanded(
-            child: stationProvider.isLoading && stationProvider.stations.isEmpty
+            child:
+                (stationProvider.isLoading || stationProvider.isListLoading) &&
+                    sorted.isEmpty
                 ? const LoadingIndicator()
                 : RefreshIndicator(
                     onRefresh: () async {
                       try {
-                        await stationProvider.refreshStations();
+                        await stationProvider.loadSortedStations();
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(

--- a/lib/services/backend_api_client.dart
+++ b/lib/services/backend_api_client.dart
@@ -22,6 +22,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:http/http.dart' as http;
 
 import '../config/api_config.dart';
+import '../models/current_price.dart';
 import '../models/fuel_type.dart';
 import '../models/price_history_point.dart';
 import '../models/price_report.dart';
@@ -116,37 +117,6 @@ class BackendApiClient {
     ];
   }
 
-  Future<List<Station>> getStationsByBbox({
-    required double minLat,
-    required double minLng,
-    required double maxLat,
-    required double maxLng,
-  }) async {
-    final data = await get(
-      '/stations/bbox',
-      queryParams: {
-        'minLat': minLat.toString(),
-        'minLng': minLng.toString(),
-        'maxLat': maxLat.toString(),
-        'maxLng': maxLng.toString(),
-      },
-    );
-    final raw = data['stations'] as List<dynamic>;
-    return [
-      for (final item in raw)
-        Station.fromBackendJson(item as Map<String, dynamic>),
-    ];
-  }
-
-  Future<List<Station>> searchStations(String query) async {
-    final data = await get('/stations/search', queryParams: {'query': query});
-    final raw = data['stations'] as List<dynamic>;
-    return [
-      for (final item in raw)
-        Station.fromBackendJson(item as Map<String, dynamic>),
-    ];
-  }
-
   Future<void> registerPrices(
     String stationId,
     List<({FuelType fuelType, double price})> registrations,
@@ -215,6 +185,56 @@ class BackendApiClient {
     }).toList();
 
     return (history: history, recentUpdates: recentUpdates);
+  }
+
+  /// GET /stations/last-updated — no auth required.
+  Future<DateTime?> getStationsLastUpdated() async {
+    final response = await http.get(_uri('/stations/last-updated'));
+    _checkStatus(response);
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final raw = data['lastUpdatedAt'];
+    return raw != null ? DateTime.parse(raw as String) : null;
+  }
+
+  /// GET /stations/all — returns all stations without prices.
+  Future<List<Station>> getAllStations() async {
+    final data = await get('/stations/all');
+    final raw = data['stations'] as List<dynamic>;
+    return [
+      for (final item in raw)
+        Station.fromBaseJson(item as Map<String, dynamic>),
+    ];
+  }
+
+  /// GET /stations/prices?stationIds=id1&stationIds=id2...
+  /// Returns prices keyed by station ID.
+  Future<Map<String, Map<FuelType, CurrentPrice>>> getStationPrices(
+    List<String> stationIds,
+  ) async {
+    final queryString = stationIds.map((id) => 'stationIds=$id').join('&');
+    final uri = Uri.parse(
+      '${BackendConfig.baseUrl}/stations/prices?$queryString',
+    );
+    final response = await http.get(uri, headers: await _authHeaders());
+    _checkStatus(response);
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final raw = data['stations'] as List<dynamic>;
+
+    final result = <String, Map<FuelType, CurrentPrice>>{};
+    for (final item in raw) {
+      final map = item as Map<String, dynamic>;
+      final stationId = map['stationId'] as String;
+      final prices = <FuelType, CurrentPrice>{};
+      for (final p in (map['prices'] as List<dynamic>)) {
+        final price = CurrentPrice.fromBackendJson(
+          stationId,
+          p as Map<String, dynamic>,
+        );
+        prices[price.fuelType] = price;
+      }
+      result[stationId] = prices;
+    }
+    return result;
   }
 
   static double _toDouble(dynamic v) =>

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -23,23 +23,27 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/station.dart';
 
 class CacheService {
-  static const _stationsKey = 'cached_stations';
-  static const _stationsTsKey = 'cached_stations_ts';
+  static const _allStationsKey = 'cached_all_stations';
+  static const _serverLastUpdatedKey = 'stations_server_last_updated';
 
-  /// Cache TTL — data older than this is considered stale.
-  static const _ttl = Duration(minutes: 30);
-
-  static Future<void> cacheStations(List<Station> stations) async {
+  /// Cache all stations (base data, no prices).
+  static Future<void> cacheAllStations(
+    List<Station> stations,
+    DateTime serverLastUpdated,
+  ) async {
     final prefs = await SharedPreferences.getInstance();
     final json = jsonEncode(stations.map((s) => s.toJson()).toList());
-    await prefs.setString(_stationsKey, json);
-    await prefs.setInt(_stationsTsKey, DateTime.now().millisecondsSinceEpoch);
+    await prefs.setString(_allStationsKey, json);
+    await prefs.setString(
+      _serverLastUpdatedKey,
+      serverLastUpdated.toIso8601String(),
+    );
   }
 
-  static Future<List<Station>?> getCachedStations() async {
+  /// Returns cached stations, or null if no cache exists.
+  static Future<List<Station>?> getCachedAllStations() async {
     final prefs = await SharedPreferences.getInstance();
-    if (!_isFresh(prefs, _stationsTsKey)) return null;
-    final json = prefs.getString(_stationsKey);
+    final json = prefs.getString(_allStationsKey);
     if (json == null) return null;
     final list = jsonDecode(json) as List;
     return list
@@ -47,10 +51,18 @@ class CacheService {
         .toList();
   }
 
-  static bool _isFresh(SharedPreferences prefs, String tsKey) {
-    final ts = prefs.getInt(tsKey);
-    if (ts == null) return false;
-    final age = DateTime.now().millisecondsSinceEpoch - ts;
-    return age < _ttl.inMilliseconds;
+  /// Returns the server's lastUpdatedAt timestamp from the last cache, or null.
+  static Future<DateTime?> getStoredLastUpdatedAt() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_serverLastUpdatedKey);
+    if (raw == null) return null;
+    return DateTime.parse(raw);
+  }
+
+  /// Remove legacy cache keys from pre-lazy-loading versions of the app.
+  static Future<void> clearLegacyCache() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('cached_stations');
+    await prefs.remove('cached_stations_ts');
   }
 }


### PR DESCRIPTION
The following changes are to ensure:
- Less calls to the backend/reduce unecessary data fetching
- Smoother experience in app
- Less risk of getting all our price data scraped in a single call

Changes:
- Stations don't change that often, so now stations are cached and fetched on app startup IF there have been any stations updated since last time (timestamp fetched from backend)
- Prices are fetched on demand if the station itself is visible on the map (not clustered) OR if there are less than 10 stations on map OR if you are zoomed quite far in.
- But prices are only fetched if last price of a station is older than 5 minutes.
- Since prices are fetched on the demand (and all stations have either registered prices or estimates) the price display under the station is always visible, and gets a loading spinner when fetching new prices.
- Since all stations are loaded in cache the search bar can search locally for stations (no need to call backend). Note that this probably makes fuzzy matching less precice, but that can be improved later.
- Nearest filter on stations screen can also just rely on the cached stations.

Tested on Android and IOS and chrome simulators.

Note: I have a feeling it fixes the issue reported in https://github.com/Drivstoffpriser/Drivstoffpriser-App/issues/194