### PR TITLE
KAN-191 - Use automatic . formatter in edit price fields

### DIFF
--- a/lib/screens/submit_price/widgets/confirm_prices_screen.dart
+++ b/lib/screens/submit_price/widgets/confirm_prices_screen.dart
@@ -24,6 +24,7 @@ import '../../../config/app_text_styles.dart';
 import '../../../l10n/l10n_helper.dart';
 import '../../../models/fuel_type.dart';
 import '../../../services/price_sign_scanner_service.dart';
+import 'price_input_field.dart';
 
 class ConfirmPricesScreen extends StatefulWidget {
   final Uint8List imageBytes;
@@ -142,13 +143,9 @@ class _ConfirmPricesScreenState extends State<ConfirmPricesScreen> {
                               controller: _controllers[type],
                               keyboardType:
                                   const TextInputType.numberWithOptions(
-                                    decimal: true,
+                                    decimal: false,
                                   ),
-                              inputFormatters: [
-                                FilteringTextInputFormatter.allow(
-                                  RegExp(r'^\d*\.?\d{0,2}'),
-                                ),
-                              ],
+                              inputFormatters: [AutoDecimalFormatter()],
                               style: AppTextStyles.body(context),
                               decoration: InputDecoration(
                                 isDense: true,

--- a/lib/screens/submit_price/widgets/price_input_field.dart
+++ b/lib/screens/submit_price/widgets/price_input_field.dart
@@ -23,7 +23,7 @@ import '../../../config/app_text_styles.dart';
 import '../../../l10n/l10n_helper.dart';
 import '../../../models/fuel_type.dart';
 
-class _AutoDecimalFormatter extends TextInputFormatter {
+class AutoDecimalFormatter extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(
     TextEditingValue oldValue,
@@ -85,7 +85,7 @@ class PriceInputField extends StatelessWidget {
     return TextFormField(
       controller: controller,
       keyboardType: const TextInputType.numberWithOptions(decimal: false),
-      inputFormatters: [_AutoDecimalFormatter()],
+      inputFormatters: [AutoDecimalFormatter()],
       style: AppTextStyles.body(context),
       decoration: InputDecoration(
         labelText: '${fuelType.localizedName(context)} (${fuelType.unit})',


### PR DESCRIPTION
On the register price manually screen we automatically input a . when typing the price.
This functionality was missing on the edit price screen (after you take a picture) and was creating problems for IOS users because input did not accept , (comma) only ., and (some?) IOS keyboards did not have . available.

Fixes: https://github.com/Drivstoffpriser/Drivstoffpriser-App/issues/191