### PR TITLE
DRIV-0 - Submit prices together in API call

### DIFF
--- a/lib/providers/price_provider.dart
+++ b/lib/providers/price_provider.dart
@@ -86,10 +86,9 @@ class PriceProvider extends ChangeNotifier {
     return cooldownDuration - elapsed;
   }
 
-  Future<bool> submitReport({
+  Future<bool> submitReports({
     required String stationId,
-    required FuelType fuelType,
-    required double price,
+    required Map<FuelType, double> prices,
     required String userId,
   }) async {
     _isSubmitting = true;
@@ -99,12 +98,15 @@ class PriceProvider extends ChangeNotifier {
     try {
       final client = BackendApiClient();
       await client.registerPrices(stationId, [
-        (fuelType: fuelType, price: price),
+        for (final entry in prices.entries)
+          (fuelType: entry.key, price: entry.value),
       ]);
 
       final prefs = await SharedPreferences.getInstance();
-      final key = 'lastReport_${stationId}_${fuelType.name}';
-      await prefs.setString(key, DateTime.now().toIso8601String());
+      final now = DateTime.now().toIso8601String();
+      for (final fuelType in prices.keys) {
+        await prefs.setString('lastReport_${stationId}_${fuelType.name}', now);
+      }
 
       _isSubmitting = false;
       notifyListeners();

--- a/lib/screens/submit_price/submit_price_screen.dart
+++ b/lib/screens/submit_price/submit_price_screen.dart
@@ -252,22 +252,13 @@ class _SubmitPriceScreenState extends State<SubmitPriceScreen> {
 
     setState(() => _isSubmitting = true);
 
-    int successCount = 0;
-    String? lastError;
-
-    for (final entry in toSubmit.entries) {
-      final success = await priceProvider.submitReport(
-        stationId: widget.station.id,
-        fuelType: entry.key,
-        price: entry.value,
-        userId: userId,
-      );
-      if (success) {
-        successCount++;
-      } else {
-        lastError = priceProvider.error;
-      }
-    }
+    final success = await priceProvider.submitReports(
+      stationId: widget.station.id,
+      prices: toSubmit,
+      userId: userId,
+    );
+    final int successCount = success ? toSubmit.length : 0;
+    final String? lastError = success ? null : priceProvider.error;
 
     if (!mounted) return;
     setState(() => _isSubmitting = false);


### PR DESCRIPTION
The backend supports and expects multiple price fuel type registrations in the same request body, but the frontend was sending one call per fuel type to the API in a for loop instead.