### PR TITLE
Increase max report distance from 1000m to 3000m

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -33,7 +33,7 @@ class AppConstants {
   static const int defaultSearchRadiusMeters = 20000;
 
   // Max distance (meters) from station to submit a price report
-  static const double maxReportDistanceMeters = 1000;
+  static const double maxReportDistanceMeters = 3000;
 
   // Price validation range (NOK)
   static const double minFuelPrice = 5.0;


### PR DESCRIPTION
Users report they cannot submit prices if they park a short drive away from the station after passing it. This increases the allowed maximum distance to 3km to accommodate this use case, while still preventing spam submissions from very far away.

Fixes #200