### PR TITLE
DRIV-0 - Fix release and ios workflows

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -3,6 +3,7 @@ name: iOS TestFlight Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: v${{ inputs.version }}+${{ steps.build_number.outputs.value }}
           name: Release ${{ inputs.version }} (${{ steps.build_number.outputs.value }})
           files: |


### PR DESCRIPTION
IOS testflight workflow needs the token set to trigger release, and we should be able to trigger it manually too.
