### PR TITLE
DRIV-0 - Push to release branch on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,3 +98,4 @@ jobs:
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: release ${NEW_VERSION} [release]"
           git push
+          git push origin HEAD:release


### PR DESCRIPTION
This pushes the release commit to a branch called "release" which can be used to auto-deploy the web app to Netlify.
Pushes to main will instead be deployed to staging.drivstoffpriser.net