### PR TITLE
DRIV-200 - Set max distance to 3000m for price registration

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -33,7 +33,7 @@ class AppConstants {
   static const int defaultSearchRadiusMeters = 20000;
 
   // Max distance (meters) from station to submit a price report
-  static const double maxReportDistanceMeters = 1000;
+  static const double maxReportDistanceMeters = 3000;
 
   // Price validation range (NOK)
   static const double minFuelPrice = 5.0;


### PR DESCRIPTION
Multiple users have reported that it is too strict, so we try increasing max distance from station to register price to 3000m.

Fixes https://github.com/Drivstoffpriser/Drivstoffpriser-App/issues/200