### PR TITLE
DRIV-0 - Fix price loading reliability and add cross-session price cache

### DIFF
--- a/lib/providers/station_provider.dart
+++ b/lib/providers/station_provider.dart
@@ -105,6 +105,24 @@ class StationProvider extends ChangeNotifier {
         notifyListeners();
       }
 
+      // 1b. Merge cached prices so markers show prices immediately.
+      final cachedPrices = await CacheService.getCachedPrices();
+      if (cachedPrices != null) {
+        final now = DateTime.now();
+        for (final entry in cachedPrices.prices.entries) {
+          final station = _allStations[entry.key];
+          if (station == null) continue;
+          _allStations[entry.key] = station.copyWithPrices(entry.value);
+          // Restore the TTL timestamp only if the cache is still fresh,
+          // so stale prices display immediately but trigger a re-fetch.
+          final ft = cachedPrices.fetchedAt[entry.key]!;
+          if (now.difference(ft) < CacheService.priceCacheTtl) {
+            _priceFetchedAt[entry.key] = ft;
+          }
+        }
+        notifyListeners();
+      }
+
       // 2. Check server timestamp (no auth needed).
       final client = BackendApiClient();
       DateTime? serverLastUpdated;
@@ -197,6 +215,7 @@ class StationProvider extends ChangeNotifier {
         _recomputeBestMapStation();
         notifyListeners();
       }
+      CacheService.cachePrices(_allStations, _priceFetchedAt);
     } catch (e) {
       debugPrint('Failed to load prices: $e');
     } finally {
@@ -494,6 +513,7 @@ class StationProvider extends ChangeNotifier {
       _allStations = {for (final s in stations) s.id: s};
       _priceFetchedAt.clear();
       _listStations = [];
+      await CacheService.clearPriceCache();
 
       final serverLastUpdated = await client.getStationsLastUpdated();
       if (serverLastUpdated != null) {

--- a/lib/screens/map/map_screen.dart
+++ b/lib/screens/map/map_screen.dart
@@ -143,34 +143,39 @@ class _MapScreenState extends State<MapScreen> {
     // which makes clearing here safe.
     _clusteredStationIds.clear();
     _priceDebounce?.cancel();
-    _priceDebounce = Timer(const Duration(milliseconds: 500), () {
-      if (!mounted) return;
-      final stationProvider = context.read<StationProvider>();
-      final all = stationProvider.brandFilteredStations;
-      if (all.isEmpty) return;
+    _priceDebounce = Timer(
+      hasGesture
+          ? const Duration(milliseconds: 250)
+          : const Duration(milliseconds: 50),
+      () {
+        if (!mounted) return;
+        final stationProvider = context.read<StationProvider>();
+        final all = stationProvider.brandFilteredStations;
+        if (all.isEmpty) return;
 
-      final bounds = camera.visibleBounds;
-      final visibleIds = <String>[];
-      final unclusteredVisibleIds = <String>[];
-      for (final s in all) {
-        if (s.latitude < bounds.south || s.latitude > bounds.north) continue;
-        if (s.longitude < bounds.west || s.longitude > bounds.east) continue;
-        visibleIds.add(s.id);
-        if (!_clusteredStationIds.contains(s.id)) {
-          unclusteredVisibleIds.add(s.id);
+        final bounds = camera.visibleBounds;
+        final visibleIds = <String>[];
+        final unclusteredVisibleIds = <String>[];
+        for (final s in all) {
+          if (s.latitude < bounds.south || s.latitude > bounds.north) continue;
+          if (s.longitude < bounds.west || s.longitude > bounds.east) continue;
+          visibleIds.add(s.id);
+          if (!_clusteredStationIds.contains(s.id)) {
+            unclusteredVisibleIds.add(s.id);
+          }
         }
-      }
 
-      // If only a handful of stations are visible, just fetch for all of them
-      // regardless of cluster state — every marker should show a price.
-      // Otherwise fetch only for the individually-rendered (unclustered) ones,
-      // since cluster bubbles never display prices.
-      final ids = visibleIds.length <= _kPriceFetchAllThreshold
-          ? visibleIds
-          : unclusteredVisibleIds;
-      if (ids.isEmpty) return;
-      stationProvider.loadPricesForStations(ids);
-    });
+        // If only a handful of stations are visible, just fetch for all of them
+        // regardless of cluster state — every marker should show a price.
+        // Otherwise fetch only for the individually-rendered (unclustered) ones,
+        // since cluster bubbles never display prices.
+        final ids = visibleIds.length <= _kPriceFetchAllThreshold
+            ? visibleIds
+            : unclusteredVisibleIds;
+        if (ids.isEmpty) return;
+        stationProvider.loadPricesForStations(ids);
+      },
+    );
   }
 
   @override

--- a/lib/services/cache_service.dart
+++ b/lib/services/cache_service.dart
@@ -20,11 +20,17 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../models/current_price.dart';
+import '../models/fuel_type.dart';
 import '../models/station.dart';
 
 class CacheService {
   static const _allStationsKey = 'cached_all_stations';
   static const _serverLastUpdatedKey = 'stations_server_last_updated';
+  static const _pricesCacheKey = 'cached_prices';
+
+  /// TTL for the cross-session price cache.
+  static const priceCacheTtl = Duration(hours: 1);
 
   /// Cache all stations (base data, no prices).
   static Future<void> cacheAllStations(
@@ -64,5 +70,58 @@ class CacheService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('cached_stations');
     await prefs.remove('cached_stations_ts');
+  }
+
+  /// Persist prices and fetch timestamps for stations that have prices.
+  static Future<void> cachePrices(
+    Map<String, Station> stations,
+    Map<String, DateTime> fetchedAt,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = <String, dynamic>{};
+    for (final entry in fetchedAt.entries) {
+      final station = stations[entry.key];
+      if (station == null || station.prices.isEmpty) continue;
+      data[entry.key] = {
+        'prices': station.prices.values.map((p) => p.toJson()).toList(),
+        'fetchedAt': entry.value.toIso8601String(),
+      };
+    }
+    await prefs.setString(_pricesCacheKey, jsonEncode(data));
+  }
+
+  /// Returns cached prices and fetch timestamps, or null if no cache exists.
+  static Future<
+    ({
+      Map<String, Map<FuelType, CurrentPrice>> prices,
+      Map<String, DateTime> fetchedAt,
+    })?
+  >
+  getCachedPrices() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_pricesCacheKey);
+    if (raw == null) return null;
+    try {
+      final data = jsonDecode(raw) as Map<String, dynamic>;
+      final prices = <String, Map<FuelType, CurrentPrice>>{};
+      final fetchedAt = <String, DateTime>{};
+      for (final entry in data.entries) {
+        final m = entry.value as Map<String, dynamic>;
+        final priceList = (m['prices'] as List)
+            .map((p) => CurrentPrice.fromJson(p as Map<String, dynamic>))
+            .toList();
+        prices[entry.key] = {for (final p in priceList) p.fuelType: p};
+        fetchedAt[entry.key] = DateTime.parse(m['fetchedAt'] as String);
+      }
+      return (prices: prices, fetchedAt: fetchedAt);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Clear the price cache (called on full station refresh).
+  static Future<void> clearPriceCache() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_pricesCacheKey);
   }
 }


### PR DESCRIPTION
Prices were not reliably shown on initial map load because programmatic camera moves (GPS centering, tile nudge on map ready) each reset the 500ms debounce timer, causing cascading delays that made prices appear to never load. Fix by splitting debounce by event type: 50ms for programmatic moves (hasGesture=false) and 250ms for user pan/zoom.

Prices were also lost between sessions since only station metadata was persisted — every cold start re-fetched all prices from scratch. Add a cross-session price cache in SharedPreferences (key: cached_prices) with a 1-hour TTL. On startup, cached prices are merged into stations immediately so markers show prices before any network call. Stale prices (older than 1h) are still shown but trigger a background re-fetch. Cache is cleared on full station refresh.